### PR TITLE
Introduce docs section

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2,6 +2,8 @@
 
 ## Current Plugins
 
+Plugins and their features that are currently provided as part of the WSUWP Platform in production.
+
 ### Must Use Plugins (mu-plugins)
 
 Must use plugins, installed in `wp-content/mu-plugins/`, are included globally by default and contain some of the required functionality for the WSUWP Platform. These plugins cannot be disabled on a site or network level.
@@ -16,11 +18,15 @@ Plugins that are useful in a local development area, but that will not necessari
 
 ## Plugins in Progress
 
+Plugins and features that have been vetted and determined to be useful for the WSUWP Platform. Progress will need to be made toward certifying these plugins for production.
+
 ### WSU Plugins
 
 ### Open Source Plugins
 
 ## Plugins to Consider
+
+Plugins and features that need to be vetted before including them in a process to deploy into production.
 
 ### Open Source Plugins
 


### PR DESCRIPTION
Markdown files in a `docs/` directory will serve the purpose of documenting the various pieces of the platform.

The initial file will be `plugins.md` and should contain some of the plugins under consideration, in use, or an indicator of functionality desired.

This structure will likely change over time. Ideally it can be used in the future to generate some sort of documentation describing the platform on `web.wsu.edu`.
