### PR TITLE
[PR] Remove both references to get_current_site_name()

### DIFF
--- a/www/wp-content/mu-plugins/wsu-core-functions.php
+++ b/www/wp-content/mu-plugins/wsu-core-functions.php
@@ -92,7 +92,6 @@ function wsuwp_switch_to_network( $network_id ) {
 	$new_network = wsuwp_get_networks( array( 'network_id' => $network_id ) );
 	$current_site = array_shift( $new_network );
 	$current_site->blog_id = $wpdb->get_var( $wpdb->prepare( "SELECT blog_id FROM $wpdb->blogs WHERE domain = %s AND path = %s", $current_site->domain, $current_site->path ) );
-	//$current_site = get_current_site_name( $current_site );
 	$wpdb->set_blog_id( $current_site->blog_id, $current_site->id );
 
 	return true;

--- a/www/wp-content/sunrise.php
+++ b/www/wp-content/sunrise.php
@@ -115,9 +115,6 @@ if( $current_blog ) {
 		// Add blog ID after the fact because it is required by both scenarios
 		$current_site->blog_id = $blog_id;
 
-		// Attach the site name to our current_site object. This uses cache already.
-		//$current_site = get_current_site_name( $current_site );
-
 		wp_cache_set( 'wsuwp:network:' . $site_id, $current_site, '', 60 * 60 * 12 );
 	}
 


### PR DESCRIPTION
This was deprecated in WordPress 3.9 and there should be no reason
for either use. If it's really needed we can find a more appropriate
way to provide the information at a later time.

Closes #49
