### PR TITLE
[PR] Fix strict PHP notices in wordpress-importer

### DIFF
--- a/www/wp-content/plugins/wordpress-importer/parsers.php
+++ b/www/wp-content/plugins/wordpress-importer/parsers.php
@@ -401,12 +401,12 @@ class WXR_Parser_Regex {
 	var $terms = array();
 	var $base_url = '';
 
-	function WXR_Parser_Regex() {
-		$this->__construct();
-	}
-
 	function __construct() {
 		$this->has_gzip = is_callable( 'gzopen' );
+	}
+
+	function WXR_Parser_Regex() {
+		$this->__construct();
 	}
 
 	function parse( $file ) {

--- a/www/wp-content/plugins/wordpress-importer/wordpress-importer.php
+++ b/www/wp-content/plugins/wordpress-importer/wordpress-importer.php
@@ -1107,7 +1107,7 @@ class WP_Import extends WP_Importer {
 	 * Added to http_request_timeout filter to force timeout at 60 seconds during import
 	 * @return int 60
 	 */
-	function bump_request_timeout() {
+	function bump_request_timeout( $val ) {
 		return 60;
 	}
 


### PR DESCRIPTION
Per upstream changes in https://plugins.trac.wordpress.org/changeset/718670/wordpress-importer
