### PR TITLE
[PR] Allow a site's domain and path to be quickly changed

### DIFF
--- a/www/wp-content/mu-plugins/wsu-network-site-info.php
+++ b/www/wp-content/mu-plugins/wsu-network-site-info.php
@@ -64,13 +64,17 @@ class WSU_Network_Site_Info {
 		if ( isset($_REQUEST['action']) && 'update-site' == $_REQUEST['action'] ) {
 			check_admin_referer( 'edit-site' );
 
+			// Lookup the current site and clear site bootstrap cache for it.
+			$id = absint( $_REQUEST['id'] );
+			$current_details = get_blog_details( $id );
+			wp_cache_delete( $current_details->domain . $current_details->path, 'wsuwp:site' );
+
+			// Look for a request to move a site between networks.
 			if ( isset( $_POST['wsu_network_id'] ) ) {
 				$network_id = absint( $_POST['wsu_network_id'] );
-				$id = absint( $_REQUEST['id'] );
 				if ( 0 === $network_id || 0 === $id ) {
 					return;
 				}
-				$current_details = get_blog_details( $id );
 				if ( $network_id != $current_details->site_id ) {
 					$current_details->site_id = $network_id;
 					update_blog_details( $id, $current_details );


### PR DESCRIPTION
A previous update to allow sites to be moved between networks prevented the domains and paths of sites from being deleted properly. This restores that behavior.
