### PR TITLE
[PR] Configure default image sizes when new sites are created

### DIFF
--- a/www/wp-content/install.php
+++ b/www/wp-content/install.php
@@ -122,6 +122,23 @@ function wp_install_defaults( $user_id ) {
 	update_option( 'widget_meta',            array ( 2 => array ( 'title' => '' ), '_multiwidget' => 1 ) );
 	update_option( 'sidebars_widgets',       array ( 'wp_inactive_widgets' => array (), 'sidebar-1' => array ( 0 => 'search-2', 1 => 'recent-posts-2', 2 => 'recent-comments-2', 3 => 'archives-2', 4 => 'categories-2', 5 => 'meta-2', ), 'sidebar-2' => array (), 'sidebar-3' => array (), 'array_version' => 3 ) );
 
+	// Setup default image sizes, allowing them to be filtered.
+	$default_image_sizes = array(
+		'thumbnail_size_w' => 198,
+		'thumbnail_size_h' => 198,
+		'medium_size_w'    => 396,
+		'medium_size_h'    => 99164,
+		'large_size_w'     => 792,
+		'large_size_h'     => 99164,
+	);
+	$image_sizes = apply_filters( 'wsuwp_install_default_image_sizes', $default_image_sizes );
+
+	foreach ( $image_sizes as $size => $val ) {
+		if ( array_key_exists( $size, $default_image_sizes ) ) {
+			update_option( $size, absint( $val ) );
+		}
+	}
+
 	if ( ! is_super_admin( $user_id ) && ! metadata_exists( 'user', $user_id, 'show_welcome_panel' ) ) {
 		update_user_meta( $user_id, 'show_welcome_panel', 2 );
 	}


### PR DESCRIPTION
This takes the burden off of the spine parent theme.

We provide a filter for `wsuwp_install_default_image_sizes` so that this can be overridden. We should test the effectiveness in themes and plugins
