### PR TITLE
[PR] Override default upload URL on all sites to force structure

### DIFF
--- a/www/wp-content/mu-plugins/wsu-core-filters.php
+++ b/www/wp-content/mu-plugins/wsu-core-filters.php
@@ -6,3 +6,33 @@ Description: Various filters used to modify core data.
 Author: washingtonstateuniversity, jeremyfelt
 Version: 0.1
 */
+
+/**
+ * ms_files_rewriting should never be enabled.
+ */
+add_filter( 'pre_option_ms_files_rewriting', '__return_false' );
+
+/**
+ * We should always use yearmonth folders for uploads.
+ */
+add_filter( 'pre_option_uploads_use_yearmonth_folders', '__return_true' );
+
+add_filter( 'upload_dir', 'wsuwp_upload_dir' );
+/**
+ * @param array $uploads Data associated with the upload URL. We assume the subdir key is correct.
+ */
+function wsuwp_upload_dir( $uploads ) {
+	if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+		return $uploads;
+	}
+
+	$site_id = get_current_blog_id();
+
+	$uploads['basedir'] = WP_CONTENT_DIR . '/uploads/sites/' . $site_id;
+	$uploads['baseurl'] = content_url() . '/uploads/sites/' . $site_id;
+
+	$uploads['path'] = $uploads['basedir'] . $uploads['subdir'];
+	$uploads['url'] = $uploads['baseurl'] . $uploads['subdir'];
+
+	return $uploads;
+}


### PR DESCRIPTION
We know that we won't be using ms-files to process files or storing
files in a directory structure other than year/month uploads.

This overwrites anything previously set by forcing sites to use the
sites portion of the uploads directory for storing content.

Definitely warrants further thought, but this will correct some
strange issues that have popped up recently
