### PR TITLE
[PR] Hide batcache debug info by default

### DIFF
--- a/www/wp-content/advanced-cache.php
+++ b/www/wp-content/advanced-cache.php
@@ -54,7 +54,7 @@ class batcache {
 
 	var $uncached_headers = array('transfer-encoding'); // These headers will never be cached. Apply strtolower.
 
-	var $debug   = true; // Set false to hide the batcache info <!-- comment -->
+	var $debug   = false; // Set false to hide the batcache info <!-- comment -->
 
 	var $cache_control = true; // Set false to disable Last-Modified and Cache-Control headers
 


### PR DESCRIPTION
We'll work around this in another way at some point, but this will
help avoid debug info being entered into places we don't need it.
