### PR TITLE
[PR] Proper management of globally active plugins

### DIFF
--- a/www/wp-content/mu-plugins/wsu-core-functions.php
+++ b/www/wp-content/mu-plugins/wsu-core-functions.php
@@ -373,6 +373,28 @@ function wsuwp_activate_global_plugin( $plugin ) {
 }
 
 /**
+ * Deactivate a plugin globally on all sites in all networks.
+ *
+ * @param string $plugin Slug of the plugin to be deactivated.
+ */
+function wsuwp_deactivate_global_plugin( $plugin ) {
+	$networks = wsuwp_get_networks();
+	foreach ( $networks as $network ) {
+		wsuwp_switch_to_network( $network->id );
+		$current = get_site_option( 'active_sitewide_plugins', array() );
+		unset( $current[ $plugin ] );
+		update_site_option( 'active_sitewide_plugins', $current );
+		wsuwp_restore_current_network();
+	}
+
+	wsuwp_switch_to_network( wsuwp_get_primary_network_id() );
+	$current_global = get_site_option( 'active_global_plugins', array() );
+	unset( $current_global[ $plugin ] );
+	update_site_option( 'active_global_plugins', $current_global );
+	wsuwp_restore_current_network();
+}
+
+/**
  * Determine if a plugin has been activated globally.
  *
  * @param $plugin String representing the plugin.

--- a/www/wp-content/mu-plugins/wsu-network-admin.php
+++ b/www/wp-content/mu-plugins/wsu-network-admin.php
@@ -79,6 +79,7 @@ class WSU_Network_Admin {
 		add_filter( 'network_admin_plugin_action_links', array( $this, 'remove_plugin_action_links' ), 10, 2 );
 		add_filter( 'network_admin_plugin_action_links', array( $this, 'plugin_action_links'        ), 15, 2 );
 		add_action( 'activate_plugin',                   array( $this, 'activate_global_plugin'     ), 10, 1 );
+		add_action( 'deactivate_plugin', array( $this, 'deactivate_global_plugin' ), 10, 1 );
 		add_filter( 'views_plugins-network',             array( $this, 'add_plugin_table_views',    ), 10, 1 );
 		add_filter( 'all_plugins',                       array( $this, 'all_plugins',               ), 10, 1 );
 		add_filter( 'parent_file',                       array( $this, 'parent_file',               ), 10, 1 );
@@ -210,6 +211,20 @@ class WSU_Network_Admin {
 			return null;
 
 		wsuwp_activate_global_plugin( $plugin );
+	}
+
+	/**
+	 * Deactivate a plugin globally on all sites in all networks.
+	 * @param $plugin
+	 *
+	 * @return null
+	 */
+	public function deactivate_global_plugin( $plugin ) {
+		if ( ! isset( $_GET['wsu-deactivate-global'] ) || ! is_main_network() ) {
+			return null;
+		}
+
+		wsuwp_deactivate_global_plugin( $plugin );
 	}
 
 	/**


### PR DESCRIPTION
- [x] New networks inherit globally active plugins.
- [x] Deactivate Globally now works as intended.
