### PR TITLE
[PR] Account for individual plugins and themes in build process

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,6 +50,12 @@ module.exports = function(grunt) {
 						src: ['**', '!README.md'],
 						dest: 'build/wp-content/plugins/',
 						cwd: 'build-plugins/private'
+					},
+					{
+						expand: true,
+						src: ['**', '!README.md'],
+						dest: 'build/wp-content/plugins/',
+						cwd: 'build-plugins/individual'
 					}
 				]
 			},
@@ -66,6 +72,12 @@ module.exports = function(grunt) {
 						src: ['**', '!README.md'],
 						dest: 'build/wp-content/themes/',
 						cwd: 'build-themes/private'
+					},
+					{
+						expand: true,
+						src: ['**', '!README.md'],
+						dest: 'build/wp-content/themes/',
+						cwd: 'build-themes/individual'
 					}
 				]
 			}


### PR DESCRIPTION
Some plugins and themes make sense as part of a larger, distributable
repository that a group can share. Other plugins and themes make
sense as individuals.

Adding an individual directory to our build-plugins and build-themes
setup allows for a more detailed deployment configuration that can
handle the plugins and themes it chooses to.
