### PR TITLE
[PR] Before checking current screen, make sure we're in wp-admin/

### DIFF
--- a/www/wp-content/mu-plugins/wsu-network-users.php
+++ b/www/wp-content/mu-plugins/wsu-network-users.php
@@ -382,7 +382,7 @@ class WSU_Network_Users {
 		/* @var WPDB $wpdb */
 		global $wpdb;
 
-		if ( 'users-network' !== get_current_screen()->id ) {
+		if ( ! is_admin() || 'users-network' !== get_current_screen()->id ) {
 			return;
 		}
 


### PR DESCRIPTION
We don't need this user query to fire on P2 views, so we can add
an extra `is_admin()` check to avoid failing on the current screen
(lack of) object here.
