### PR TITLE
[PR] Replace HTTPS mirrorlink to epel repo with HTTP via sed

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -122,6 +122,8 @@ ERRORSS
     cd /tmp && mv WSU-Web-Provisioner-master wsu-web
     cp -fr /tmp/wsu-web/provision/salt /srv/
     cp /tmp/wsu-web/provision/salt/config/local.yum.conf /etc/yum.conf
+    rpm -Uvh --force http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+    sed -i 's/mirrorlist=https/mirrorlist=http/' /etc/yum.repos.d/epel.repo
     sh /tmp/wsu-web/provision/bootstrap_salt.sh -K stable
     rm /etc/salt/minion.d/*.conf
     cp /tmp/wsu-web/provision/salt/minions/wsuwp.conf /etc/salt/minion.d/


### PR DESCRIPTION
The epel repo is served with SSL 3.0 and breaks things badly on
initial provision in the VM because of the image we're using.

For now, we can use `sed` to replace the scheme of the URL.
