### PR TITLE
[PR] Add an is_admin() check to our site request cache clear

### DIFF
--- a/www/wp-content/mu-plugins/wsu-network-admin.php
+++ b/www/wp-content/mu-plugins/wsu-network-admin.php
@@ -1015,7 +1015,7 @@ class WSU_Network_Admin {
 	 * @param $blog_id
 	 */
 	public function clear_site_request_cache( $blog_id ) {
-		if ( 'site-info-network' !== get_current_screen()->base || ! isset( $_POST['blog'] ) ) {
+		if ( ! is_admin() || 'site-info-network' !== get_current_screen()->base || ! isset( $_POST['blog'] ) ) {
 			return;
 		}
 


### PR DESCRIPTION
This causes some issues if we're using WP-CLI. In the future we
can get a bit smarter about how this is handled, so that if a
site is created or modified through WP-CLI, we still clear this
cache
