### PR TITLE
[PR] On any new site install, clear the domain/path request cache

### DIFF
--- a/www/wp-content/mu-plugins/wsu-network-site-new.php
+++ b/www/wp-content/mu-plugins/wsu-network-site-new.php
@@ -137,6 +137,9 @@ class WSUWP_New_Site_Administration {
 			update_user_option( $user_id, 'primary_blog', $id, true );
 		}
 
+		// Clear any stale cache related to this domain and path request. See sunrise.
+		wp_cache_delete( $domain . $path, 'wsuwp:site' );
+
 		$content_mail = sprintf( __( 'New site created by %1$s
 
 Address: %2$s


### PR DESCRIPTION
Resolves an issue where an old lookup may have been cached for a
non existing site.

Fixes #218
