### PR TITLE
[PR] Remove New Post and Manage Comments from admin menu if super admin

### DIFF
--- a/www/wp-content/mu-plugins/wsu-admin-header.php
+++ b/www/wp-content/mu-plugins/wsu-admin-header.php
@@ -378,7 +378,7 @@ class WSU_Admin_Header {
 					'href'   => admin_url(),
 				) );
 
-				if ( current_user_can( get_post_type_object( 'post' )->cap->create_posts ) ) {
+				if ( ! is_super_admin() && current_user_can( get_post_type_object( 'post' )->cap->create_posts ) ) {
 					$wp_admin_bar->add_menu( array(
 						'parent' => $menu_id,
 						'id'     => $menu_id . '-n',
@@ -387,7 +387,7 @@ class WSU_Admin_Header {
 					) );
 				}
 
-				if ( current_user_can( 'edit_posts' ) ) {
+				if ( ! is_super_admin() && current_user_can( 'edit_posts' ) ) {
 					$wp_admin_bar->add_menu( array(
 						'parent' => $menu_id,
 						'id'     => $menu_id . '-c',


### PR DESCRIPTION
The list of networks and sites is massive when you're a super admin on a large multinetwork install. While we think about a better way to approach this as a whole, we can make some obvious changes to reduce the size of the menu.