### PR TITLE
[PR] Add wsuwp:site to the global cache groups

### DIFF
--- a/www/wp-content/sunrise.php
+++ b/www/wp-content/sunrise.php
@@ -59,6 +59,7 @@ $requested_uri_parts = explode( '/', $requested_uri );
 $requested_path = $requested_uri_parts[0] . '/';
 
 wp_cache_add_global_groups( 'wsuwp:network' );
+wp_cache_add_global_groups( 'wsuwp:site' );
 
 // If we're dealing with a root domain, we want to leave it at a path of '/'
 if ( '/' !== $requested_path ) {


### PR DESCRIPTION
When this was not part of a global cache group, the cache key for
a new site's domain/path was caculated incorrectly and the attempt
to clear a previous 404 request for that same domain/path would
not be successful.

Now, the cached domain/path lookup is cleared properly against the
global group when a new site is added.

Old reproduction behavior:

1. Request `http://wsu.edu/this-site-is-invalid/`, get 404
2. Setup site `http://wsu.edu/this-site-is-invalid/`
3. Request `http://wsu.edu/this-site-is-invalid/`, still get 404

New behavior:

1. Request `http://wsu.edu/this-site-is-invalid/`, get 404
2. Setup site `http://wsu.edu/this-site-is-invalid/`
3. Request `http://wsu.edu/this-site-is-invalid/`, see page!