### PR TITLE
[PR] Support *.wsu.edu locally in nginx, in addition to *.wsu.dev

### DIFF
--- a/pillar/config/nginx/wp.wsu.dev.conf
+++ b/pillar/config/nginx/wp.wsu.dev.conf
@@ -2,7 +2,7 @@
 # dev.wp.wsu.edu nginx configuration
 server {
     listen       80;
-    server_name  *.wsu.dev;
+    server_name  *.wsu.dev *.wsu.edu;
     root         /var/www/wordpress;
 
     include /etc/nginx/wsuwp-common.conf;


### PR DESCRIPTION
Sometimes it's easier to use URLs such as dev.people.wsu.edu. At some point, the `.dev` TLD may be reserved anyway.