### PR TITLE
[PR] We no longer manage the sites action list

### DIFF
--- a/www/wp-content/mu-plugins/wsu-network-sites-list.php
+++ b/www/wp-content/mu-plugins/wsu-network-sites-list.php
@@ -21,7 +21,6 @@ class WSU_Network_Sites_List {
 	 */
 	public function __construct() {
 		add_filter( 'wpmu_blogs_columns', array( $this, 'site_columns' ) );
-		add_filter( 'manage_sites_action_links', array( $this, 'manage_sites_action_links' ), 10, 3 );
 		add_filter( 'bulk_actions-sites-network', array( $this, 'manage_bulk_actions' ), 10, 1 );
 		add_action( 'manage_sites_custom_column', array( $this, 'manage_sites_custom_column' ), 10, 2 );
 	}


### PR DESCRIPTION
A change in 4.3 brought this back to life and started throwing
notices. Oops. :)