### PR TITLE
[PR] WordPress: Fix a reversal of parameters to wp_schedule_single_event()

### DIFF
--- a/www/wordpress/wp-includes/taxonomy.php
+++ b/www/wordpress/wp-includes/taxonomy.php
@@ -4445,7 +4445,7 @@ function _wp_batch_split_terms() {
  */
 function _wp_check_for_scheduled_split_terms() {
 	if ( ! get_option( 'finished_splitting_shared_terms' ) && ! wp_next_scheduled( 'wp_batch_split_terms' ) ) {
-		wp_schedule_single_event( 'wp_batch_split_terms', time() + MINUTE_IN_SECONDS );
+		wp_schedule_single_event( time() + MINUTE_IN_SECONDS, 'wp_batch_split_terms' );
 	}
 }
 


### PR DESCRIPTION
https://core.trac.wordpress.org/changeset/33647 will be included
in WordPress 4.3.1 and resolves an issue where events with invalid
times are scheduled and stored indefinitely in the database.

We're skipping the cleanup right now and only preventing future
events.