### PR TITLE
[PR] Hotfix: Delete rewrite_rules when updating a switched site's URL.

### DIFF
--- a/www/wordpress/wp-admin/includes/misc.php
+++ b/www/wordpress/wp-admin/includes/misc.php
@@ -246,8 +246,11 @@ function update_home_siteurl( $old_value, $value ) {
 	if ( defined( "WP_INSTALLING" ) )
 		return;
 
-	// If home changed, write rewrite rules to new location.
-	flush_rewrite_rules();
+	if ( is_multisite() && ms_is_switched() ) {
+		delete_option( 'rewrite_rules' );
+	} else {
+		flush_rewrite_rules();
+	}
 }
 
 /**


### PR DESCRIPTION
This will be included in WordPress 4.4 and resolves an issue where
changing the site or home URL in the network admin would result in
the rewrite rules for the updated site being changed to match the
main site of the network.

https://core.trac.wordpress.org/changeset/34672
https://core.trac.wordpress.org/ticket/33816