### PR TITLE
Deploy preview of upstream #20104 for network plugins

### DIFF
--- a/www/wordpress/wp-admin/css/list-tables.css
+++ b/www/wordpress/wp-admin/css/list-tables.css
@@ -859,6 +859,11 @@ p.pagenav {
 	padding: 2px 0 0;
 }
 
+.row-actions .network_only,
+.row-actions .network_active {
+	color: #000;
+}
+
 tr:hover .row-actions,
 .mobile .row-actions,
 .row-actions.visible,

--- a/www/wordpress/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/www/wordpress/wp-admin/includes/class-wp-plugins-list-table.php
@@ -127,6 +127,24 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			}
 		}
 
+		if ( ! $screen->in_admin( 'network' ) ) {
+			$show = current_user_can( 'manage_network_plugins' );
+			/**
+			 * Filter whether to display network-activated plugins alongside site-activated plugins.
+			 *
+			 * This also controls the display of non-activated network-only plugins (plugins with
+			 * "Network: true" in the plugin header).
+			 *
+			 * Plugins cannot be network-activated or network-deactivated from this screen.
+			 *
+			 * @since 4.4.0
+			 *
+			 * @param bool $show Whether to show network-active plugins. Default is whether the current
+			 *                   user can manage network plugins (ie. a Super Admin).
+			 */
+			$show_network_active = apply_filters( 'show_network_active_plugins', $show );
+		}
+
 		set_transient( 'plugin_slugs', array_keys( $plugins['all'] ), DAY_IN_SECONDS );
 
 		if ( ! $screen->in_admin( 'network' ) ) {
@@ -159,11 +177,21 @@ class WP_Plugins_List_Table extends WP_List_Table {
 
 			// Filter into individual sections
 			if ( is_multisite() && ! $screen->in_admin( 'network' ) && is_network_only_plugin( $plugin_file ) && ! is_plugin_active( $plugin_file ) ) {
-				// On the non-network screen, filter out network-only plugins as long as they're not individually activated
-				unset( $plugins['all'][ $plugin_file ] );
+				if ( $show_network_active ) {
+					// On the non-network screen, show inactive network-only plugins if allowed
+					$plugins['inactive'][ $plugin_file ] = $plugin_data;
+				} else {
+					// On the non-network screen, filter out network-only plugins as long as they're not individually active
+					unset( $plugins['all'][ $plugin_file ] );
+				}
 			} elseif ( ! $screen->in_admin( 'network' ) && is_plugin_active_for_network( $plugin_file ) ) {
-				// On the non-network screen, filter out network activated plugins
-				unset( $plugins['all'][ $plugin_file ] );
+				if ( $show_network_active ) {
+					// On the non-network screen, show network-active plugins if allowed
+					$plugins['active'][ $plugin_file ] = $plugin_data;
+				} else {
+					// On the non-network screen, filter out network-active plugins
+					unset( $plugins['all'][ $plugin_file ] );
+				}
 			} elseif ( ( ! $screen->in_admin( 'network' ) && is_plugin_active( $plugin_file ) )
 				|| ( $screen->in_admin( 'network' ) && is_plugin_active_for_network( $plugin_file ) ) ) {
 				// On the non-network screen, populate the active list with plugins that are individually activated
@@ -483,6 +511,9 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			else
 				$is_active = is_plugin_active( $plugin_file );
 
+			$is_network_active = is_plugin_active_for_network( $plugin_file );
+			$is_network_only   = is_network_only_plugin( $plugin_file );
+
 			if ( $screen->in_admin( 'network' ) ) {
 				if ( $is_active ) {
 					if ( current_user_can( 'manage_network_plugins' ) ) {
@@ -500,7 +531,15 @@ class WP_Plugins_List_Table extends WP_List_Table {
 					}
 				}
 			} else {
-				if ( $is_active ) {
+				if ( $is_network_active ) {
+					$actions = array(
+						'network_active' => __( 'Network Active' ),
+					);
+				} elseif ( $is_network_only && ! $is_active ) {
+					$actions = array(
+						'network_only' => __( 'Network Only' ),
+					);
+				} elseif ( $is_active ) {
 					/* translators: %s: plugin name */
 					$actions['deactivate'] = '<a href="' . wp_nonce_url( 'plugins.php?action=deactivate&amp;plugin=' . $plugin_file . '&amp;plugin_status=' . $context . '&amp;paged=' . $page . '&amp;s=' . $s, 'deactivate-plugin_' . $plugin_file ) . '" aria-label="' . esc_attr( sprintf( __( 'Deactivate %s' ), $plugin_data['Name'] ) ) . '">' . __( 'Deactivate' ) . '</a>';
 				} else {
@@ -573,7 +612,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 
 		$class = $is_active ? 'active' : 'inactive';
 		$checkbox_id =  "checkbox_" . md5($plugin_data['Name']);
-		if ( in_array( $status, array( 'mustuse', 'dropins' ) ) ) {
+		if ( $is_network_active || ( $is_network_only && ! $is_active ) || in_array( $status, array( 'mustuse', 'dropins' ) ) ) {
 			$checkbox = '';
 		} else {
 			$checkbox = "<label class='screen-reader-text' for='" . $checkbox_id . "' >" . sprintf( __( 'Select %s' ), $plugin_data['Name'] ) . "</label>"


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/20104

This will show network activated plugins to network admins in a
site's plugin listing. We may be able to take advantage of the
filter to display all network activated plugins to all admins.