### PR TITLE
[PR] Update Batcache to match upstream changes from Automattic

### DIFF
--- a/www/wp-content/advanced-cache.php
+++ b/www/wp-content/advanced-cache.php
@@ -22,7 +22,7 @@ function batcache_cancel() {
 function vary_cache_on_function($function) {
 	global $batcache;
 
-	if ( preg_match('/include|require|echo|print|dump|export|open|sock|unlink|`|eval/i', $function) )
+	if ( preg_match('/include|require|echo|(?<!s)print|dump|export|open|sock|unlink|`|eval/i', $function) )
 		die('Illegal word in variant determiner.');
 
 	if ( !preg_match('/\$_/', $function) )
@@ -52,6 +52,7 @@ class batcache {
 	var $redirect_status = false; // This is set to the response code during a redirect.
 	var $redirect_location = false; // This is set to the redirect location.
 
+	var $use_stale        = true; // Is it ok to return stale cached response when updating the cache?
 	var $uncached_headers = array('transfer-encoding'); // These headers will never be cached. Apply strtolower.
 
 	var $debug   = false; // Set false to hide the batcache info <!-- comment -->
@@ -62,6 +63,7 @@ class batcache {
 
 	var $noskip_cookies = array( 'wordpress_test_cookie' ); // Names of cookies - if they exist and the cache would normally be bypassed, don't bypass it
 
+	var $query = '';
 	var $genlock = false;
 	var $do = false;
 
@@ -146,23 +148,29 @@ class batcache {
 	}
 
 	function ob($output) {
-		if ( $this->cancel !== false )
-			return $output;
-
 		// PHP5 and objects disappearing before output buffers?
 		wp_cache_init();
 
 		// Remember, $wp_object_cache was clobbered in wp-settings.php so we have to repeat this.
 		$this->configure_groups();
 
+		if ( $this->cancel !== false ) {
+			wp_cache_delete( "{$this->url_key}_genlock", $this->group );
+			return $output;
+		}
+
 		// Do not batcache blank pages unless they are HTTP redirects
 		$output = trim($output);
-		if ( $output === '' && (!$this->redirect_status || !$this->redirect_location) )
+		if ( $output === '' && (!$this->redirect_status || !$this->redirect_location) ) {
+			wp_cache_delete( "{$this->url_key}_genlock", $this->group );
 			return;
+		}
 
 		// Do not cache 5xx responses
-		if ( isset( $this->status_code ) && intval($this->status_code / 100) == 5 )
+		if ( isset( $this->status_code ) && intval($this->status_code / 100) == 5 ) {
+			wp_cache_delete( "{$this->url_key}_genlock", $this->group );
 			return $output;
+		}
 
 		$this->do_variants($this->vary);
 		$this->generate_keys();
@@ -191,8 +199,10 @@ class batcache {
 
 		foreach ( $this->cache['headers'] as $header => $values ) {
 			// Do not cache if cookies were set
-			if ( strtolower( $header ) === 'set-cookie' )
+			if ( strtolower( $header ) === 'set-cookie' ) {
+				wp_cache_delete( "{$this->url_key}_genlock", $this->group );
 				return $output;
+			}
 
 			foreach ( (array) $values as $value )
 				if ( preg_match('/^Cache-Control:.*max-?age=(\d+)/i', "$header: $value", $matches) )
@@ -250,7 +260,7 @@ class batcache {
 	function generate_keys() {
 		// ksort($this->keys); // uncomment this when traffic is slow
 		$this->key = md5(serialize($this->keys));
-		$this->req_key = $this->key . '_req';
+		$this->req_key = $this->key . '_reqs';
 	}
 
 	function add_debug_just_cached() {
@@ -294,7 +304,7 @@ HTML;
 		if ( false === $head_position ) {
 			return;
 		}
-		$this->cache['output'] = substr_replace( $this->cache['output'], $debug_html, $head_position, 0 );
+		$this->cache['output'] .= "\n$debug_html";
 	}
 }
 
@@ -312,22 +322,19 @@ if ( in_array(
 		'wp-app.php',
 		'xmlrpc.php',
 		'wp-cron.php',
-	) ) ) {
+	) ) )
 	return;
-}
-
-// Never batcache WP Document Revisions
-if ( preg_match( '/documents\/([0-9]{4})\/([0-9]{1,2})\/([^.]+)\.[A-Za-z0-9]{3,4}\/?$/', $_SERVER['REQUEST_URI'] ) ) {
-	return;
-}
 
 // Never batcache WP javascript generators
 if ( strstr( $_SERVER['SCRIPT_FILENAME'], 'wp-includes/js' ) )
 	return;
 
-// Never batcache when POST data is present.
-if ( ! empty( $GLOBALS['HTTP_RAW_POST_DATA'] ) || ! empty( $_POST ) )
+// Never batcache a POST request.
+if ( ! empty( $GLOBALS['HTTP_RAW_POST_DATA'] ) || ! empty( $_POST ) ||
+	( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] ) )
+{
 	return;
+}
 
 // Never batcache when cookies indicate a cache-exempt visitor.
 if ( is_array( $_COOKIE) && ! empty( $_COOKIE ) ) {
@@ -396,16 +403,19 @@ if ( $batcache->is_ssl() )
 // Recreate the permalink from the URL
 $batcache->permalink = 'http://' . $batcache->keys['host'] . $batcache->keys['path'] . ( isset($batcache->keys['query']['p']) ? "?p=" . $batcache->keys['query']['p'] : '' );
 $batcache->url_key = md5($batcache->permalink);
-$batcache->url_version = (int) wp_cache_get("{$batcache->url_key}_version", $batcache->group);
 $batcache->configure_groups();
+$batcache->url_version = (int) wp_cache_get("{$batcache->url_key}_version", $batcache->group);
 $batcache->do_variants();
 $batcache->generate_keys();
 
 // Get the batcache
 $batcache->cache = wp_cache_get($batcache->key, $batcache->group);
 
-// Are we only caching frequently-requested pages?
-if ( $batcache->seconds < 1 || $batcache->times < 2 ) {
+if ( isset( $batcache->cache['version'] ) && $batcache->cache['version'] != $batcache->url_version ) {
+	// Always refresh the cache if a newer version is available.
+	$batcache->do = true;
+} else if ( $batcache->seconds < 1 || $batcache->times < 2 ) {
+	// Are we only caching frequently-requested pages?
 	$batcache->do = true;
 } else {
 	// No batcache item found, or ready to sample traffic again at the end of the batcache life?
@@ -413,24 +423,28 @@ if ( $batcache->seconds < 1 || $batcache->times < 2 ) {
 		wp_cache_add($batcache->req_key, 0, $batcache->group);
 		$batcache->requests = wp_cache_incr($batcache->req_key, 1, $batcache->group);
 
-		if ( $batcache->requests >= $batcache->times )
+		if ( $batcache->requests >= $batcache->times &&
+			time() >= $batcache->cache['time'] + $batcache->cache['max_age']
+		) {
+			wp_cache_delete( $batcache->req_key, $batcache->group );
 			$batcache->do = true;
-		else
+		} else {
 			$batcache->do = false;
+		}
 	}
 }
 
-// If the document has been updated and we are the first to notice, regenerate it.
-if ( $batcache->do !== false && isset($batcache->cache['version']) && $batcache->cache['version'] < $batcache->url_version )
+// Obtain cache generation lock
+if ( $batcache->do )
 	$batcache->genlock = wp_cache_add("{$batcache->url_key}_genlock", 1, $batcache->group, 10);
 
-// Temporary: remove after 2010-11-12. I added max_age to the cache. This upgrades older caches on the fly.
-if ( !isset($batcache->cache['max_age']) )
-	$batcache->cache['max_age'] = $batcache->max_age;
-
-
-// Did we find a batcached page that hasn't expired?
-if ( isset($batcache->cache['time']) && ! $batcache->genlock && time() < $batcache->cache['time'] + $batcache->cache['max_age'] ) {
+if ( isset( $batcache->cache['time'] ) && // We have cache
+	! $batcache->genlock &&            // We have not obtained cache regeneration lock
+	(
+		time() < $batcache->cache['time'] + $batcache->cache['max_age'] || // Batcached page that hasn't expired ||
+		( $batcache->do && $batcache->use_stale )                          // Regenerating it in another request and can use stale cache
+	)
+) {
 	// Issue redirect if cached and enabled
 	if ( $batcache->cache['redirect_status'] && $batcache->cache['redirect_location'] && $batcache->cache_redirects ) {
 		$status = $batcache->cache['redirect_status'];
@@ -509,7 +523,7 @@ if ( isset($batcache->cache['time']) && ! $batcache->genlock && time() < $batcac
 }
 
 // Didn't meet the minimum condition?
-if ( !$batcache->do && !$batcache->genlock )
+if ( ! $batcache->do || ! $batcache->genlock )
 	return;
 
 $wp_filter['status_header'][10]['batcache'] = array( 'function' => array(&$batcache, 'status_header'), 'accepted_args' => 2 );
@@ -518,4 +532,3 @@ $wp_filter['wp_redirect_status'][10]['batcache'] = array( 'function' => array(&$
 ob_start(array(&$batcache, 'ob'));
 
 // It is safer to omit the final PHP closing tag.
-

--- a/www/wp-content/mu-plugins/batcache.php
+++ b/www/wp-content/mu-plugins/batcache.php
@@ -9,7 +9,7 @@ Version: 1.2
 */
 
 // Do not load if our advanced-cache.php isn't loaded
-if ( ! is_object($batcache) || ! method_exists( $wp_object_cache, 'incr' ) )
+if ( ! isset( $batcache ) || ! is_object($batcache) || ! method_exists( $wp_object_cache, 'incr' ) )
 	return;
 
 $batcache->configure_groups();
@@ -26,19 +26,38 @@ function batcache_post($post_id) {
 	global $batcache;
 
 	$post = get_post($post_id);
-	if ( empty( $post ) || $post->post_type == 'revision' || get_post_status($post_id) != 'publish' )
+	if ( $post->post_type == 'revision' || ! in_array( get_post_status($post_id), array( 'publish', 'trash' ) ) )
 		return;
 
-	batcache_clear_url( get_option('home') );
-	batcache_clear_url( trailingslashit( get_option('home') ) );
+	$home = trailingslashit( get_option('home') );
+	batcache_clear_url( $home );
+	batcache_clear_url( $home . 'feed/' );
 	batcache_clear_url( get_permalink($post_id) );
 }
 
 function batcache_clear_url($url) {
-	global $batcache;
+	global $batcache, $wp_object_cache;
+
 	if ( empty($url) )
 		return false;
-	$url_key = md5($url);
+
+	if ( 0 === strpos( $url, 'https://' ) )
+		$url = str_replace( 'https://', 'http://', $url );
+	if ( 0 !== strpos( $url, 'http://' ) )
+		$url = 'http://' . $url;
+
+	$url_key = md5( $url );
 	wp_cache_add("{$url_key}_version", 0, $batcache->group);
-	return wp_cache_incr("{$url_key}_version", 1, $batcache->group);
+	$retval = wp_cache_incr("{$url_key}_version", 1, $batcache->group);
+
+	$batcache_no_remote_group_key = array_search( $batcache->group, (array) $wp_object_cache->no_remote_groups );
+	if ( false !== $batcache_no_remote_group_key ) {
+		// The *_version key needs to be replicated remotely, otherwise invalidation won't work.
+		// The race condition here should be acceptable.
+		unset( $wp_object_cache->no_remote_groups[ $batcache_no_remote_group_key ] );
+		$retval = wp_cache_set( "{$url_key}_version", $retval, $batcache->group );
+		$wp_object_cache->no_remote_groups[ $batcache_no_remote_group_key ] = $batcache->group;
+	}
+
+	return $retval;
 }


### PR DESCRIPTION
See upstream as of: https://github.com/Automattic/batcache/tree/302a31159915c5b58b4ff85853fe4888e3a94f80

* Introduction of the `$use_stale` option, which allows us to serve a stale version of a page while cache is generated for the new version.
* Better URL expiration.