### PR TITLE
[PR] Cleanup WSUWP core functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ wp-cli.local.yml
 
 # Ignore all themes in the wp-content directory by default. We'll explicitly allow those we track here.
 /www/wp-content/themes/*/
+
+# Ignore optional webgrind directory for local development.
+/www/webgrind
+
+# Ignore WSU Spine when in www for local development.
+/www/wsu-spine

--- a/www/wp-content/mu-plugins/wsu-core-functions.php
+++ b/www/wp-content/mu-plugins/wsu-core-functions.php
@@ -123,28 +123,6 @@ function wsuwp_restore_current_network() {
 }
 
 /**
- * Wrapper function for the WordPress switch_to_blog() intended to better match the
- * name of what we're doing in the backend vs the frontend
- *
- * @param int $site_id ID of the site to switch to
- *
- * @return bool True on success, false if the validation failed
- */
-function wsuwp_switch_to_site( $site_id ) {
-	return switch_to_blog( $site_id );
-}
-
-/**
- * Used after wsuwp_switch_to_site(), this is a wrapper for restore_current_blog() that gets
- * us back to the current site
- *
- * @return bool True on success, false if we're already on the current blog
- */
-function wsuwp_restore_current_site() {
-	return restore_current_blog();
-}
-
-/**
  * Checks to see if there is more than one network defined in the site table
  *
  * @return bool

--- a/www/wp-content/mu-plugins/wsu-core-functions.php
+++ b/www/wp-content/mu-plugins/wsu-core-functions.php
@@ -331,7 +331,7 @@ function wsuwp_activate_global_plugin( $plugin ) {
 		wsuwp_restore_current_network();
 	}
 
-	wsuwp_switch_to_network( wsuwp_get_primary_network_id() );
+	wsuwp_switch_to_network( get_main_network_id() );
 	$current_global = get_site_option( 'active_global_plugins', array() );
 	$current_global[ $plugin ] = time();
 	update_site_option( 'active_global_plugins', $current_global );
@@ -353,7 +353,7 @@ function wsuwp_deactivate_global_plugin( $plugin ) {
 		wsuwp_restore_current_network();
 	}
 
-	wsuwp_switch_to_network( wsuwp_get_primary_network_id() );
+	wsuwp_switch_to_network( get_main_network_id() );
 	$current_global = get_site_option( 'active_global_plugins', array() );
 	unset( $current_global[ $plugin ] );
 	update_site_option( 'active_global_plugins', $current_global );
@@ -388,44 +388,11 @@ function wsuwp_get_active_global_plugins() {
 	if ( ! wsuwp_is_multi_network() )
 		return false;
 
-	wsuwp_switch_to_network( wsuwp_get_primary_network_id() );
+	wsuwp_switch_to_network( get_main_network_id() );
 	$current_global = get_site_option( 'active_global_plugins', array() );
 	wsuwp_restore_current_network();
 
 	return $current_global;
-}
-
-/**
- * Retrieve the primary network id.
- *
- * If a multinetwork setup, retrieve the primary network ID. If a multisite
- * setup, return 1. If a standard WordPress installation, return 1.
- *
- * @return int The primary network id.
- */
-function wsuwp_get_primary_network_id() {
-	global $current_site, $wpdb;
-
-	$current_network_id = (int) $current_site->id;
-
-	if ( ! is_multisite() || ! wsuwp_is_multi_network() )
-		return 1;
-
-	if ( defined( 'PRIMARY_NETWORK_ID' ) )
-		return PRIMARY_NETWORK_ID;
-
-	if ( 1 === $current_network_id )
-		return 1;
-
-	$primary_network_id = (int) wp_cache_get( 'primary_network_id', 'site-options' );
-
-	if ( $primary_network_id )
-		return $primary_network_id;
-
-	$primary_network_id = (int) $wpdb->get_var( "SELECT id FROM $wpdb->site ORDER BY id LIMIT 1" );
-	wp_cache_add( 'primary_network_id', $primary_network_id, 'site-options' );
-
-	return $primary_network_id;
 }
 
 /**
@@ -525,7 +492,7 @@ function wsuwp_network_user_count( $network_id = 0 ) {
 function wsuwp_global_site_count() {
 	global $wpdb;
 
-	wsuwp_switch_to_network( wsuwp_get_primary_network_id() );
+	wsuwp_switch_to_network( get_main_network_id() );
 	$global_site_data = get_site_option( 'global_site_data', array( 'count' => 0, 'updated' => 0 ) );
 
 	if ( empty( $global_site_data['count'] ) || empty( $global_site_data['updated'] ) || ( time() - 1800 ) > absint( $global_site_data['updated'] ) ) {

--- a/www/wp-content/mu-plugins/wsu-dashboard-widgets.php
+++ b/www/wp-content/mu-plugins/wsu-dashboard-widgets.php
@@ -55,7 +55,7 @@ class WSUWP_WordPress_Dashboard {
 		remove_meta_box( 'dashboard_primary'          , 'dashboard-network', 'side'   );
 		remove_meta_box( 'dashboard_secondary'        , 'dashboard-network', 'side'   );
 
-		if ( wsuwp_get_primary_network_id() == wsuwp_get_current_network()->id ) {
+		if ( get_main_network_id() == wsuwp_get_current_network()->id ) {
 			$count_title = 'WSUWP Platform Counts';
 		} else {
 			$network_name = get_site_option( 'site_name' );
@@ -63,7 +63,7 @@ class WSUWP_WordPress_Dashboard {
 		}
 		wp_add_dashboard_widget( 'dashboard_wsuwp_counts', $count_title, array( $this, 'network_dashboard_counts' ) );
 
-		if ( wsuwp_get_primary_network_id() == wsuwp_get_current_network()->id ) {
+		if ( get_main_network_id() == wsuwp_get_current_network()->id ) {
 			wp_add_dashboard_widget( 'dashboard_wsuwp_memcached', 'Global Memcached Usage', array( $this, 'global_memcached_stats' ) );
 		}
 	}
@@ -73,7 +73,7 @@ class WSUWP_WordPress_Dashboard {
 	 * when viewing the network administration dashboard.
 	 */
 	public function network_dashboard_counts() {
-		if ( wsuwp_get_current_network()->id == wsuwp_get_primary_network_id() ) {
+		if ( wsuwp_get_current_network()->id == get_main_network_id() ) {
 			?>
 			<h4>Global</h4>
 			<ul class="wsuwp-platform-counts wsuwp-count-above wsuwp-count-thirds">

--- a/www/wp-content/mu-plugins/wsu-network-admin.php
+++ b/www/wp-content/mu-plugins/wsu-network-admin.php
@@ -904,7 +904,7 @@ class WSU_Network_Admin {
 		}
 
 		if ( get_site_option( 'wpmu_upgrade_site' ) != $wp_db_version ) {
-			$primary_network_id = wsuwp_get_primary_network_id();
+			$primary_network_id = get_main_network_id();
 			wsuwp_switch_to_network( $primary_network_id );
 			$global_admin_url = esc_url( network_admin_url( '/upgrade.php?action=global_upgrade' ) );
 			wsuwp_restore_current_network();
@@ -1104,7 +1104,7 @@ class WSU_Network_Admin {
 	public function update_network_user_count( $value ) {
 		global $wpdb;
 
-		if ( $wpdb->siteid == wsuwp_get_primary_network_id() ) {
+		if ( $wpdb->siteid == get_main_network_id() ) {
 			return $value;
 		}
 

--- a/www/wp-content/mu-plugins/wsu-network-users.php
+++ b/www/wp-content/mu-plugins/wsu-network-users.php
@@ -70,7 +70,7 @@ class WSU_Network_Users {
 	 * @return array List of global admins.
 	 */
 	public function get_global_admins() {
-		wsuwp_switch_to_network( wsuwp_get_primary_network_id() );
+		wsuwp_switch_to_network( get_main_network_id() );
 		$global_admins = get_site_option( 'site_admins', array() );
 		wsuwp_restore_current_network();
 
@@ -392,7 +392,7 @@ class WSU_Network_Users {
 		}
 
 		// The primary network (global) should show all users.
-		if ( wsuwp_get_primary_network_id() == wsuwp_get_current_network()->id ) {
+		if ( get_main_network_id() == wsuwp_get_current_network()->id ) {
 			return;
 		}
 


### PR DESCRIPTION
* Remove unused site switching functions, defer to built in core functionality.
* Remove `wsuwp_get_primary_network_id()` now that its replacement is available in WordPress 4.3.