### PR TITLE
[PR] Override the wp_get_sites query limit from 100 to 200

### DIFF
--- a/www/wp-content/mu-plugins/wsu-admin-header.php
+++ b/www/wp-content/mu-plugins/wsu-admin-header.php
@@ -352,7 +352,7 @@ class WSU_Admin_Header {
 				),
 			));
 
-			$sites = wp_get_sites( array( 'network_id' => $network->id ) );
+			$sites = wp_get_sites( array( 'network_id' => $network->id, 'limit' => 200 ) );
 			$network_sites_added = 0;
 
 			// Add a unique site search menu for each network to aid with long lists.


### PR DESCRIPTION
This was causing an issue where if a network had more than 100 sites, some would be missing from various admin menus depending on the user.