### PR TITLE
[PR] Remove handling of "extended" network options, all networks are the same

### DIFF
--- a/www/wp-content/mu-plugins/js/wsu-move-site.js
+++ b/www/wp-content/mu-plugins/js/wsu-move-site.js
@@ -6,11 +6,6 @@
 (function($){
 	var form_table = $('.form-table');
 	var move_site = $('#wsu-move-site');
-	var extend_site = $('#wsuwp-extended-site');
-
-	form_table.prepend( extend_site );
 	form_table.prepend( move_site );
-
-	extend_site.show();
 	move_site.show();
 }(jQuery));

--- a/www/wp-content/mu-plugins/wsu-network-admin.php
+++ b/www/wp-content/mu-plugins/wsu-network-admin.php
@@ -90,7 +90,6 @@ class WSU_Network_Admin {
 
 		add_filter( 'pre_site_option_upload_filetypes', array( $this, 'set_upload_filetypes' ), 10, 1 );
 		add_filter( 'upload_mimes', array( $this, 'set_mime_types' ), 10, 1 );
-		add_filter( 'wsuwp_extended_upload_filetypes', array( $this, 'set_extended_upload_filetypes' ), 10, 1 );
 
 		add_filter( 'pre_site_option_add_new_users', array( $this, 'set_add_new_users' ), 10, 1 );
 		add_filter( 'pre_site_option_registrationnotification', array( $this, 'set_registrationnotification' ), 10, 1 );
@@ -788,9 +787,9 @@ class WSU_Network_Admin {
 	public function set_upload_filetypes() {
 		$network_options = $this->get_global_network_options();
 
-		// Sites with extended permissions are allowed a different fileset.
-		if ( 'extended' === get_option( 'wsuwp_extended_site', false ) ) {
-			$network_options['upload_filetypes'] = apply_filters( 'wsuwp_extended_upload_filetypes', $network_options['upload_filetypes'] );
+		// Global admins can upload EXE files.
+		if ( is_super_admin() ) {
+			$network_options['upload_filetypes'] .= ' exe';
 		}
 
 		return $network_options['upload_filetypes'];
@@ -824,10 +823,6 @@ class WSU_Network_Admin {
 	 */
 	public function set_extended_upload_filetypes( $upload_filetypes ) {
 		$upload_filetypes = trim( $upload_filetypes ) . ' ' . $this->extended_network_options['upload_filetypes'];
-
-		if ( is_super_admin() ) {
-			$upload_filetypes .= ' exe';
-		}
 
 		return $upload_filetypes;
 	}

--- a/www/wp-content/mu-plugins/wsu-network-admin.php
+++ b/www/wp-content/mu-plugins/wsu-network-admin.php
@@ -54,17 +54,6 @@ class WSU_Network_Admin {
 	);
 
 	/**
-	 * These options are applied to sites that are marked to receive extended
-	 * permissions.
-	 *
-	 * @var array List of extended network options.
-	 */
-	private $extended_network_options = array(
-		'fileupload_maxk' => 200000,
-		'upload_filetypes' => 'dmg zip',
-	);
-
-	/**
 	 * Add the filters and actions used
 	 */
 	public function __construct() {
@@ -760,15 +749,6 @@ class WSU_Network_Admin {
 	}
 
 	/**
-	 * Apply the extended value for max upload size.
-	 *
-	 * @return int Size in KB
-	 */
-	public function set_extended_fileupload_maxk() {
-		return $this->extended_network_options['fileupload_maxk'];
-	}
-
-	/**
 	 * Return the default value for total site upload space.
 	 *
 	 * @return int Size in MB
@@ -812,19 +792,6 @@ class WSU_Network_Admin {
 		}
 
 		return $mime_types;
-	}
-
-	/**
-	 * Add extended filetypes to the default list allowed for networks.
-	 *
-	 * @param string $upload_filetypes Space delimited list of allowed filetypes.
-	 *
-	 * @return string Modified list of allowed filetypes.
-	 */
-	public function set_extended_upload_filetypes( $upload_filetypes ) {
-		$upload_filetypes = trim( $upload_filetypes ) . ' ' . $this->extended_network_options['upload_filetypes'];
-
-		return $upload_filetypes;
 	}
 
 	/**

--- a/www/wp-content/mu-plugins/wsu-network-admin.php
+++ b/www/wp-content/mu-plugins/wsu-network-admin.php
@@ -86,8 +86,6 @@ class WSU_Network_Admin {
 		add_filter( 'parent_file',                       array( $this, 'parent_file',               ), 10, 1 );
 
 		add_filter( 'pre_site_option_fileupload_maxk', array( $this, 'set_fileupload_maxk' ), 10, 1 );
-		add_filter( 'wsuwp_extended_fileupload_maxk', array( $this, 'set_extended_fileupload_maxk' ), 10, 1 );
-
 		add_filter( 'pre_site_option_blog_upload_space', array( $this, 'set_blog_upload_space' ), 10, 1 );
 
 		add_filter( 'pre_site_option_upload_filetypes', array( $this, 'set_upload_filetypes' ), 10, 1 );
@@ -758,10 +756,6 @@ class WSU_Network_Admin {
 	 */
 	public function set_fileupload_maxk() {
 		$network_options = $this->get_global_network_options();
-
-		if ( 'extended' === get_option( 'wsuwp_extended_site', false ) ) {
-			$network_options['fileupload_maxk'] = apply_filters( 'wsuwp_extended_fileupload_maxk', $network_options['fileupload_maxk'] );
-		}
 
 		return $network_options['fileupload_maxk'];
 	}

--- a/www/wp-content/mu-plugins/wsu-network-admin.php
+++ b/www/wp-content/mu-plugins/wsu-network-admin.php
@@ -46,7 +46,7 @@ class WSU_Network_Admin {
 	private $global_network_options = array(
 		'fileupload_maxk' => 200000,
 		'blog_upload_space' => 2000,
-		'upload_filetypes' => 'jpg jpeg png gif mp3 webp oga ogg ogv webm mp4 pdf ai psd eps doc ppt xls csv key numbers pages',
+		'upload_filetypes' => 'jpg jpeg png gif mp3 webp oga ogg ogv webm mp4 pdf ai psd eps doc ppt xls csv key numbers pages dmg zip',
 		'add_new_users' => 1,
 		'registrationnotification' => 'no',
 		'registration' => 'none',

--- a/www/wp-content/mu-plugins/wsu-network-admin.php
+++ b/www/wp-content/mu-plugins/wsu-network-admin.php
@@ -628,11 +628,6 @@ class WSU_Network_Admin {
 			}
 		}
 
-		// Look for a request to apply extended permissions to a network.
-		if ( isset( $_POST['wsuwp_extended_site'] ) && in_array( $_POST['wsuwp_extended_site'], array( '0', 'extended' ) ) ) {
-			update_blog_option( wsuwp_get_current_network()->blog_id, 'wsuwp_extended_site', $_POST['wsuwp_extended_site'] );
-		}
-
 		wsuwp_restore_current_network();
 	}
 

--- a/www/wp-content/mu-plugins/wsu-network-site-info.php
+++ b/www/wp-content/mu-plugins/wsu-network-site-info.php
@@ -19,7 +19,6 @@ class WSU_Network_Site_Info {
 	 */
 	public function __construct() {
 		add_action( 'admin_footer', array( $this, 'display_move_site' ), 10 );
-		add_action( 'admin_footer', array( $this, 'display_extended_site' ), 11 );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 10 );
 		add_action( 'admin_action_update-site', array( $this, 'update_site' ), 10 );
@@ -54,43 +53,6 @@ class WSU_Network_Site_Info {
 	}
 
 	/**
-	 * Display an option to apply extended permissions to a site on the network.
-	 */
-	public function display_extended_site() {
-		global $id;
-
-		if ( 'site-info-network' !== get_current_screen()->id || ! is_super_admin() ) {
-			return;
-		}
-
-		$enabled = '';
-		if ( isset( $_GET['network_id'] ) ) {
-			$network_id = absint( $_GET['network_id'] );
-			wsuwp_switch_to_network( $network_id );
-			$extended_status = get_blog_option( wsuwp_get_current_network()->blog_id, 'wsuwp_extended_site', '0' );
-			wsuwp_restore_current_network();
-		} else if ( $id ) {
-			switch_to_blog( $id );
-			$extended_status = get_option( 'wsuwp_extended_site', '0' );
-			restore_current_blog();
-		} else {
-			$extended_status = '0';
-			$enabled = 'disabled="disabled"';
-		}
-
-		?>
-		<table style="display:none;"><tr id="wsuwp-extended-site" class="form-field form-required">
-				<th scope="row"><?php _e( 'Extended' ); ?></th>
-				<td><select name="wsuwp_extended_site" <?php echo $enabled; ?>>
-						<option value="0" <?php selected( $extended_status, '0', true ); ?>>Disabled</option>
-						<option value="extended" <?php selected( $extended_status, 'extended', true ); ?>>Extended</option>
-				</select></td>
-		</tr></table>
-		<?php
-
-	}
-
-	/**
 	 * Enqueue a script to reposition the move site DIV on load.
 	 */
 	public function enqueue_scripts() {
@@ -114,13 +76,6 @@ class WSU_Network_Site_Info {
 			$id = absint( $_REQUEST['id'] );
 			$current_details = get_blog_details( $id );
 			wp_cache_delete( $current_details->domain . $current_details->path, 'wsuwp:site' );
-
-			// When editing the primary site for a network, look for a request to apply extended permissions to the network.
-			if ( isset( $_POST['wsuwp_extended_site'] ) && in_array( $_POST['wsuwp_extended_site'], array( '0', 'extended' ) ) ) {
-				switch_to_blog( $id );
-				update_option( 'wsuwp_extended_site', $_POST['wsuwp_extended_site'] );
-				restore_current_blog();
-			}
 
 			// Process a request to move a site between networks.
 			if ( isset( $_POST['wsu_network_id'] ) ) {


### PR DESCRIPTION
This relaxes file upload restrictions a bit and allows anyone to upload `zip` files, which are more common than we originally thought.