### PR TITLE
[PR] Remove filter used to enable the Spine Builder template

### DIFF
--- a/www/wp-content/mu-plugins/index.php
+++ b/www/wp-content/mu-plugins/index.php
@@ -12,8 +12,6 @@
 $wsuwp_global_version = '1.4.1';
 $wsuwp_wp_changeset = '36463-forked';
 
-add_filter( 'spine_enable_builder_module', '__return_true' );
-
 /**
  * Returns the current deployment version of WSUWP Platform
  *


### PR DESCRIPTION
* This shouldn't be part of the platform in the first place as
  it is very WSU specific.
* We now enable the builder by default in the Spine Parent theme
  because that was a weird decision not to.