### PR TITLE
[PR] Improve network caching

### DIFF
--- a/www/wp-content/mu-plugins/wsu-core-functions.php
+++ b/www/wp-content/mu-plugins/wsu-core-functions.php
@@ -162,7 +162,12 @@ function wsuwp_get_networks( $args = array() ) {
 		return array();
 	}
 
-	$network_results = (array) $wpdb->get_results( "SELECT * FROM $wpdb->site" );
+	$network_results = wp_cache_get( 'networks', 'wsuwp' );
+
+	if ( ! $network_results ) {
+		$network_results = (array) $wpdb->get_results( "SELECT * FROM $wpdb->site" );
+		wp_cache_add( 'networks', $network_results, 'wsuwp', 86400 );
+	}
 
 	if ( isset( $args['network_id'] ) ) {
 		$network_id = (array) $args['network_id'];

--- a/www/wp-content/mu-plugins/wsu-core-functions.php
+++ b/www/wp-content/mu-plugins/wsu-core-functions.php
@@ -234,6 +234,8 @@ function wsuwp_create_network( $args ) {
 	$wpdb->insert( $wpdb->site, array( 'domain' => $args['domain'], 'path' => $args['path'] ) );
 	$network_id = $wpdb->insert_id;
 
+	wp_cache_delete( 'networks', 'wsuwp' );
+
 	// Assume the current network's admins will have access
 	$network_admins = get_site_option( 'site_admins' );
 


### PR DESCRIPTION
This adds a 24 hour cache to the results of `SELECT * FROM wp_site`. The surrounding function, `wsuwp_get_networks()`, fires somewhere around 29 times in the admin.

@philcable #reviewmerge?