### PR TITLE
[PR] Account for port numbers in sunrise routing

### DIFF
--- a/www/wp-content/sunrise.php
+++ b/www/wp-content/sunrise.php
@@ -197,7 +197,7 @@ if( $current_blog ) {
 		header( "Location: http://" . $redirect_domain, true, 301 );
 	} else {
 		error_log( 'Sunrise: Redirecting invalid domain to default site - ' . $requested_domain );
-		header( "Location: http://wp.wsu.edu/", true, 301 );
+		header( "Location: https://wp.wsu.edu/", true, 301 );
 	}
 
 	die();

--- a/www/wp-content/sunrise.php
+++ b/www/wp-content/sunrise.php
@@ -50,9 +50,18 @@ if ( defined( 'COOKIE_DOMAIN' ) ) {
 	die( 'The constant "COOKIE_DOMAIN" is defined (probably in wp-config.php). Please remove or comment out that define() line.' );
 }
 
-//Capture the domain and path from the current request
-$requested_domain    = $_SERVER['HTTP_HOST'];
+// Capture the domain and path from the current request
+$requested_domain = strtolower( $_SERVER['HTTP_HOST'] );
 $requested_uri       = trim( $_SERVER['REQUEST_URI'], '/' );
+
+// Strip any port numbers from the HTTP_HOST data.
+if ( substr( $requested_domain, -3 ) == ':80' ) {
+	$requested_domain = substr( $requested_domain, 0, -3 );
+	$_SERVER['HTTP_HOST'] = substr( $_SERVER['HTTP_HOST'], 0, -3 );
+} elseif ( substr( $requested_domain, -4 ) == ':443' ) {
+	$requested_domain = substr( $requested_domain, 0, -4 );
+	$_SERVER['HTTP_HOST'] = substr( $_SERVER['HTTP_HOST'], 0, -4 );
+}
 
 // We currently support one subdirectory deep, and therefore only look at the first path level
 $requested_uri_parts = explode( '/', $requested_uri );

--- a/www/wp-content/sunrise.php
+++ b/www/wp-content/sunrise.php
@@ -55,10 +55,10 @@ $requested_domain = strtolower( $_SERVER['HTTP_HOST'] );
 $requested_uri       = trim( $_SERVER['REQUEST_URI'], '/' );
 
 // Strip any port numbers from the HTTP_HOST data.
-if ( substr( $requested_domain, -3 ) == ':80' ) {
+if ( ':80' === substr( $requested_domain, -3 ) ) {
 	$requested_domain = substr( $requested_domain, 0, -3 );
 	$_SERVER['HTTP_HOST'] = substr( $_SERVER['HTTP_HOST'], 0, -3 );
-} elseif ( substr( $requested_domain, -4 ) == ':443' ) {
+} elseif ( ':443' === substr( $requested_domain, -4 ) ) {
 	$requested_domain = substr( $requested_domain, 0, -4 );
 	$_SERVER['HTTP_HOST'] = substr( $_SERVER['HTTP_HOST'], 0, -4 );
 }


### PR DESCRIPTION
If a request comes in for `wp.wsu.edu:443`, our subsequent handling of the domain would send `wp.wsu.edu:443` to the database to look for a record. Instead, we can mimic WordPress itself and strip ports 443 and 80 from the request if they appear.