### PR TITLE
[PR] Update platform for WordPress 4.6 compatibility

### DIFF
--- a/www/wp-content/mu-plugins/wsu-admin-header.php
+++ b/www/wp-content/mu-plugins/wsu-admin-header.php
@@ -358,7 +358,7 @@ class WSU_Admin_Header {
 				),
 			));
 
-			$sites = wp_get_sites( array( 'network_id' => $network->id, 'limit' => 200 ) );
+			$sites = get_sites( array( 'network_id' => $network->id ) );
 			$network_sites_added = 0;
 
 			// Add a unique site search menu for each network to aid with long lists.
@@ -374,23 +374,21 @@ class WSU_Admin_Header {
 
 			// Add each of the user's sites from this specific network to the menu
 			foreach( $sites as $site ) {
-				switch_to_blog( $site['blog_id'] );
+				switch_to_blog( $site->id );
 
 				if ( ! current_user_can( 'manage_network', $network->id ) && ! is_user_member_of_blog() ) {
 					restore_current_blog();
 					continue;
 				}
 
-				$site_details = get_blog_details();
-
 				$blavatar = '<div class="blavatar"></div>';
 
-				$menu_id  = 'site-' . $site['blog_id'];
+				$menu_id  = 'site-' . $site->id;
 
 				$wp_admin_bar->add_menu( array(
 					'parent'    => 'network-' . $network->id . '-list',
 					'id'        => $menu_id,
-					'title'     => $blavatar . $site_details->blogname,
+					'title'     => $blavatar . $site->blogname,
 					'href'      => admin_url(),
 				) );
 

--- a/www/wp-content/mu-plugins/wsu-core-functions.php
+++ b/www/wp-content/mu-plugins/wsu-core-functions.php
@@ -12,7 +12,6 @@
 /**
  * Return a list of networks that the user is a member of.
  *
- * @uses wsuwp_get_networks
  * @param null $user_id Optional. Defaults to the current user.
  *
  * @return array containing list of user's networks
@@ -27,7 +26,7 @@ function wsuwp_get_user_networks( $user_id = null ) {
 
 	// Global admins should see every network.
 	if ( is_super_admin() ) {
-		return wsuwp_get_networks();
+		return get_networks();
 	}
 
 	$user_id = absint( $user_id );
@@ -42,7 +41,7 @@ function wsuwp_get_user_networks( $user_id = null ) {
 		}
 	}
 
-	return wsuwp_get_networks( array( 'network_id' => $user_network_ids ) );
+	return get_networks( array( 'network__in' => $user_network_ids ) );
 }
 
 /**
@@ -327,7 +326,7 @@ We hope you enjoy your new site. Thanks!
  * @param string $plugin Slug of the plugin to be activated.
  */
 function wsuwp_activate_global_plugin( $plugin ) {
-	$networks = wsuwp_get_networks();
+	$networks = get_networks();
 	foreach ( $networks as $network ) {
 		wsuwp_switch_to_network( $network->id );
 		$current = get_site_option( 'active_sitewide_plugins', array() );
@@ -349,7 +348,7 @@ function wsuwp_activate_global_plugin( $plugin ) {
  * @param string $plugin Slug of the plugin to be deactivated.
  */
 function wsuwp_deactivate_global_plugin( $plugin ) {
-	$networks = wsuwp_get_networks();
+	$networks = get_networks();
 	foreach ( $networks as $network ) {
 		wsuwp_switch_to_network( $network->id );
 		$current = get_site_option( 'active_sitewide_plugins', array() );
@@ -440,7 +439,7 @@ function wsuwp_validate_path( $path ) {
  * @return int The number of networks currently configured.
  */
 function wsuwp_network_count() {
-	$network_count = count( wsuwp_get_networks() );
+	$network_count = get_networks( array( 'count' => true ) );
 	return $network_count;
 }
 

--- a/www/wp-content/mu-plugins/wsu-core-functions.php
+++ b/www/wp-content/mu-plugins/wsu-core-functions.php
@@ -77,12 +77,13 @@ function wsuwp_get_current_site() {
  *     - site_name
  *     - cookie_domain (?)
  *
- * @param int $network_id Network ID to switch to.
+ * @global WP_Network $current_site The current network.
+ * @global wpdb       $wpdb         WordPress database abstraction object.
  *
+ * @param int $network_id Network ID to switch to.
  * @return bool
  */
 function wsuwp_switch_to_network( $network_id ) {
-	/** @type WPDB $wpdb */
 	global $current_site, $wpdb;
 
 	if ( ! $network_id ) {
@@ -101,10 +102,12 @@ function wsuwp_switch_to_network( $network_id ) {
 /**
  * Restore the last network that was in use before switching.
  *
+ * @global WP_Network $current_site The current network.
+ * @global wpdb       $wpdb         WordPress database abstraction object.
+ *
  * @return bool False if there were no networks to switch back to. True if a stack was available.
  */
 function wsuwp_restore_current_network() {
-	/** @type WPDB $wpdb */
 	global $current_site, $wpdb;
 
 	if ( empty( $GLOBALS['_wsuwp_switched_stack'] ) ) {
@@ -121,6 +124,8 @@ function wsuwp_restore_current_network() {
 
 /**
  * Checks to see if there is more than one network defined in the site table
+ *
+ * @global wpdb $wpdb WordPress database abstraction object.
  *
  * @return bool
  */
@@ -147,9 +152,10 @@ function wsuwp_is_multi_network() {
 /**
  * Get an array of data on requested networks
  *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
  * @param array $args Optional.
  *     - 'network_id' a single network ID or an array of network IDs
- *
  * @return array containing network data
  */
 function wsuwp_get_networks( $args = array() ) {
@@ -178,8 +184,15 @@ function wsuwp_get_networks( $args = array() ) {
 	return array_values( $network_results );
 }
 
+/**
+ * Create a network.
+ *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
+ * @param $args
+ * @return int
+ */
 function wsuwp_create_network( $args ) {
-	/** @type WPDB $wpdb */
 	global $wpdb;
 
 	$errors = new WP_Error();
@@ -250,8 +263,16 @@ function wsuwp_create_network( $args ) {
 	return $network_id; // maybe even a network object
 }
 
+/**
+ * Populate a new network's meta information.
+ *
+ * @global wpdb   $wpdb          WordPress database abstraction object.
+ * @global string $wp_db_version
+ *
+ * @param $network_id
+ * @param $network_meta
+ */
 function wsuwp_populate_network_meta( $network_id, $network_meta ) {
-	/** @type WPDB $wpdb */
 	global $wpdb, $wp_db_version;
 
 	$welcome_email = __( 'Dear User,
@@ -463,8 +484,9 @@ function wsuwp_global_user_count() {
  * This data will be generated every 30 minutes. Generation is initiated via
  * an attempt to use the function.
  *
- * @param int $network_id Network ID
+ * @global wpdb $wpdb WordPress database abstraction object.
  *
+ * @param int $network_id Network ID
  * @return int Count of users on the network
  */
 function wsuwp_network_user_count( $network_id = 0 ) {

--- a/www/wp-content/mu-plugins/wsu-core-functions.php
+++ b/www/wp-content/mu-plugins/wsu-core-functions.php
@@ -494,13 +494,11 @@ function wsuwp_network_user_count( $network_id = 0 ) {
  * @return int Count of sites on the global platform.
  */
 function wsuwp_global_site_count() {
-	global $wpdb;
-
 	wsuwp_switch_to_network( get_main_network_id() );
 	$global_site_data = get_site_option( 'global_site_data', array( 'count' => 0, 'updated' => 0 ) );
 
 	if ( empty( $global_site_data['count'] ) || empty( $global_site_data['updated'] ) || ( time() - 1800 ) > absint( $global_site_data['updated'] ) ) {
-		$count = $wpdb->get_var( "SELECT COUNT(blog_id) as c FROM $wpdb->blogs WHERE spam = '0' AND deleted = '0' and archived = '0'" );
+		$count = get_sites( array( 'number' => '', 'spam' => 0, 'deleted' => 0, 'archived' => 0, 'count' => true ) );
 		$global_site_data = array( 'count' => absint( $count ), 'updated' => time() );
 		update_site_option( 'global_site_data', $global_site_data );
 	}

--- a/www/wp-content/mu-plugins/wsu-core-functions.php
+++ b/www/wp-content/mu-plugins/wsu-core-functions.php
@@ -1,10 +1,10 @@
 <?php
 /*
  * Plugin Name: WSU Core Functions
- * Plugin URI: http://web.wsu.edu
+ * Plugin URI: https://web.wsu.edu
  * Description: Functions that perform some core functionality that we would love to live inside of WordPress one day.
  * Author: washingtonstateuniversity, jeremyfelt
- * Author URI: http://web.wsu.edu
+ * Author URI: https://web.wsu.edu
  * Version: 0.1
  * Network: true
  */
@@ -12,12 +12,12 @@
 /**
  * Return a list of networks that the user is a member of.
  *
- * @param null $user_id Optional. Defaults to the current user.
+ * @global wpdb $wpdb WordPress database abstraction object.
  *
- * @return array containing list of user's networks
+ * @param int|null $user_id Optional. Defaults to the current user.
+ * @return array Array containing a list of the user's networks.
  */
 function wsuwp_get_user_networks( $user_id = null ) {
-	/* @var WPDB $wpdb */
 	global $wpdb;
 
 	if ( ! $user_id ) {

--- a/www/wp-content/mu-plugins/wsu-core-functions.php
+++ b/www/wp-content/mu-plugins/wsu-core-functions.php
@@ -471,7 +471,7 @@ function wsuwp_network_user_count( $network_id = 0 ) {
 	global $wpdb;
 
 	if ( 0 === $network_id ) {
-		$network_id = wsuwp_get_current_network()->id;
+		$network_id = get_current_network_id();
 	}
 
 	wsuwp_switch_to_network( $network_id );

--- a/www/wp-content/mu-plugins/wsu-core-functions.php
+++ b/www/wp-content/mu-plugins/wsu-core-functions.php
@@ -62,7 +62,7 @@ function wsuwp_get_current_network() {
  * @return object with current site information
  */
 function wsuwp_get_current_site() {
-	return get_blog_details();
+	return get_site();
 }
 
 /**

--- a/www/wp-content/mu-plugins/wsu-core-functions.php
+++ b/www/wp-content/mu-plugins/wsu-core-functions.php
@@ -93,10 +93,8 @@ function wsuwp_switch_to_network( $network_id ) {
 	// Create a backup of $current_site in the global scope.
 	$GLOBALS['_wsuwp_switched_stack'][] = array( 'network' => $current_site, 'blog_id' => $wpdb->blogid, 'site_id' => $wpdb->siteid );
 
-	$new_network = wsuwp_get_networks( array( 'network_id' => $network_id ) );
-	$current_site = array_shift( $new_network );
-	$current_site->blog_id = $wpdb->get_var( $wpdb->prepare( "SELECT blog_id FROM $wpdb->blogs WHERE domain = %s AND path = %s", $current_site->domain, $current_site->path ) );
-	$wpdb->set_blog_id( $current_site->blog_id, $current_site->id );
+	$current_site = get_network( $network_id );
+	$wpdb->set_blog_id( $current_site->site_id, $current_site->id );
 
 	return true;
 }

--- a/www/wp-content/mu-plugins/wsu-dashboard-widgets.php
+++ b/www/wp-content/mu-plugins/wsu-dashboard-widgets.php
@@ -55,7 +55,7 @@ class WSUWP_WordPress_Dashboard {
 		remove_meta_box( 'dashboard_primary'          , 'dashboard-network', 'side'   );
 		remove_meta_box( 'dashboard_secondary'        , 'dashboard-network', 'side'   );
 
-		if ( get_main_network_id() == wsuwp_get_current_network()->id ) {
+		if ( get_main_network_id() == get_current_network_id() ) {
 			$count_title = 'WSUWP Platform Counts';
 		} else {
 			$network_name = get_site_option( 'site_name' );
@@ -63,7 +63,7 @@ class WSUWP_WordPress_Dashboard {
 		}
 		wp_add_dashboard_widget( 'dashboard_wsuwp_counts', $count_title, array( $this, 'network_dashboard_counts' ) );
 
-		if ( get_main_network_id() == wsuwp_get_current_network()->id ) {
+		if ( get_main_network_id() == get_current_network_id() ) {
 			wp_add_dashboard_widget( 'dashboard_wsuwp_memcached', 'Global Memcached Usage', array( $this, 'global_memcached_stats' ) );
 		}
 	}
@@ -73,7 +73,7 @@ class WSUWP_WordPress_Dashboard {
 	 * when viewing the network administration dashboard.
 	 */
 	public function network_dashboard_counts() {
-		if ( wsuwp_get_current_network()->id == get_main_network_id() ) {
+		if ( get_current_network_id() == get_main_network_id() ) {
 			?>
 			<h4>Global</h4>
 			<ul class="wsuwp-platform-counts wsuwp-count-above wsuwp-count-thirds">
@@ -87,7 +87,7 @@ class WSUWP_WordPress_Dashboard {
 		<h4>Network</h4>
 		<ul class="wsuwp-platform-counts">
 			<li id="dash-network-sites"><a href="<?php echo esc_url( network_admin_url( 'sites.php' ) ); ?>"><?php echo esc_html( get_site_option( 'blog_count' ) ); ?></a></li>
-			<li id="dash-network-users"><a href="<?php echo esc_url( network_admin_url( 'users.php' ) ); ?>"><?php echo wsuwp_network_user_count( wsuwp_get_current_network()->id ); ?></a></li>
+			<li id="dash-network-users"><a href="<?php echo esc_url( network_admin_url( 'users.php' ) ); ?>"><?php echo wsuwp_network_user_count( get_current_network_id() ); ?></a></li>
 		</ul>
 		<?php
 	}

--- a/www/wp-content/mu-plugins/wsu-network-admin.php
+++ b/www/wp-content/mu-plugins/wsu-network-admin.php
@@ -855,7 +855,7 @@ class WSU_Network_Admin {
 	 * @param $blog_id
 	 */
 	public function clear_site_request_cache( $blog_id ) {
-		$site_details = get_blog_details( $blog_id, true );
+		$site_details = get_site( $blog_id );
 
 		// Remove the cache attached to the old domain and path.
 		wp_cache_delete( $site_details->domain . $site_details->path, 'wsuwp:site' );

--- a/www/wp-content/mu-plugins/wsu-network-admin.php
+++ b/www/wp-content/mu-plugins/wsu-network-admin.php
@@ -667,7 +667,7 @@ class WSU_Network_Admin {
 
 		require( ABSPATH . 'wp-admin/admin-header.php' );
 
-		$network = wsuwp_get_networks( array( 'network_id' => $network_id ) );
+		$network = get_network( $network_id );
 
 		$query = $wpdb->prepare( "SELECT * FROM {$wpdb->sitemeta} WHERE site_id = %d", $network_id );
 		$network_data = $wpdb->get_results( $query, ARRAY_A );
@@ -684,7 +684,7 @@ class WSU_Network_Admin {
 		);
 		?>
 		<div class="wrap">
-			<h2 id="edit-network"><?php _e( 'Edit Network' ); ?>: <?php echo $network[0]->domain; ?></h2>
+			<h2 id="edit-network"><?php _e( 'Edit Network' ); ?>: <?php echo $network->domain; ?></h2>
 			<?php
 			$display_output = '';
 			$edit_output = '';
@@ -710,14 +710,14 @@ class WSU_Network_Admin {
 						<th scope="row">
 							<label for="network[domain]">Network Domain:</label>
 						</th>
-						<td><input class="wide-text" type="text" name="network[domain]" value="<?php echo esc_attr( $network[0]->domain ); ?>">
+						<td><input class="wide-text" type="text" name="network[domain]" value="<?php echo esc_attr( $network->domain ); ?>">
 						<p class="description">Changing the domain or path of an existing network may have severe consequences.</p></td>
 					</tr>
 					<tr class="form-field">
 						<th scope="row">
 							<label for="network[path]">Network Path:</label>
 						</th>
-						<td><input class="wide-text" type="text" name="network[path]" value="<?php echo esc_attr( $network[0]->path ); ?>"></td>
+						<td><input class="wide-text" type="text" name="network[path]" value="<?php echo esc_attr( $network->path ); ?>"></td>
 					</tr>
 					<?php echo $edit_output; ?>
 					<tr class="form-field">

--- a/www/wp-content/mu-plugins/wsu-network-site-info.php
+++ b/www/wp-content/mu-plugins/wsu-network-site-info.php
@@ -34,7 +34,7 @@ class WSU_Network_Site_Info {
 			return;
 		}
 
-		$site_network_id = get_blog_details( $id )->site_id;
+		$site_network_id = get_site( $id )->network_id;
 		?>
 		<table style="display:none;"><tr id="wsu-move-site" class="form-field form-required">
 			<th scope="row"><?php _e( 'Network' ) ?></th>
@@ -74,7 +74,7 @@ class WSU_Network_Site_Info {
 
 			// Lookup the current site and clear site bootstrap cache for it.
 			$id = absint( $_REQUEST['id'] );
-			$current_details = get_blog_details( $id );
+			$current_details = get_site( $id );
 			wp_cache_delete( $current_details->domain . $current_details->path, 'wsuwp:site' );
 
 			// Process a request to move a site between networks.

--- a/www/wp-content/mu-plugins/wsu-network-site-info.php
+++ b/www/wp-content/mu-plugins/wsu-network-site-info.php
@@ -40,7 +40,7 @@ class WSU_Network_Site_Info {
 			<th scope="row"><?php _e( 'Network' ) ?></th>
 			<td><select name="wsu_network_id">
 		<?php
-		$networks = wsuwp_get_networks();
+		$networks = get_networks();
 		foreach( $networks as $network ) {
 			echo '<option value="' . $network->id . '" ' . selected( $site_network_id, $network->id, false ) . '>' . $network->domain . $network->path . '</option>';
 		}

--- a/www/wp-content/mu-plugins/wsu-network-sites-list.php
+++ b/www/wp-content/mu-plugins/wsu-network-sites-list.php
@@ -107,7 +107,7 @@ class WSU_Network_Sites_List {
 	 */
 	private function display_site_created( $site_id ) {
 		switch_to_blog( $site_id );
-		$site_details = get_blog_details();
+		$site_details = get_site();
 		restore_current_blog();
 
 		if ( isset( $site_details->registered ) ) {

--- a/www/wp-content/mu-plugins/wsu-network-users.php
+++ b/www/wp-content/mu-plugins/wsu-network-users.php
@@ -107,7 +107,7 @@ class WSU_Network_Users {
 	 * @param int $user_id User ID of a new user added to a network.
 	 */
 	public function add_user_to_network( $user_id ) {
-		$network_id = absint( wsuwp_get_current_network()->id );
+		$network_id = absint( get_current_network_id() );
 		if ( 0 < $network_id ) {
 			add_user_meta( $user_id, 'wsuwp_network_' . $network_id . '_capabilities', array(), true );
 		}
@@ -180,7 +180,7 @@ class WSU_Network_Users {
 			<table class="form-table">
 				<tr>
 					<th><?php _e( 'Network Admin' ); ?></th>
-					<td><p><label><input type="checkbox" id="network_admin"  name="network_admin" <?php checked( user_can( $profile_user->ID, 'manage_network', wsuwp_get_current_network()->id ) ); ?> /><?php _e( 'Grant this user admin privileges for the Network.' ); ?></label></p></td>
+					<td><p><label><input type="checkbox" id="network_admin"  name="network_admin" <?php checked( user_can( $profile_user->ID, 'manage_network', get_current_network_id() ) ); ?> /><?php _e( 'Grant this user admin privileges for the Network.' ); ?></label></p></td>
 				</tr>
 			</table>
 		<?php
@@ -277,7 +277,7 @@ class WSU_Network_Users {
 	 */
 	public function is_network_admin( $user_login, $network_id = 0 ) {
 		if ( 0 === absint( $network_id ) ) {
-			$network_id = wsuwp_get_current_network()->id;
+			$network_id = get_current_network_id();
 		}
 
 		$network_id = absint( $network_id );
@@ -438,7 +438,7 @@ class WSU_Network_Users {
 		}
 
 		// The primary network (global) should show all users.
-		if ( get_main_network_id() == wsuwp_get_current_network()->id ) {
+		if ( get_main_network_id() == get_current_network_id() ) {
 			return;
 		}
 
@@ -450,7 +450,7 @@ class WSU_Network_Users {
 
 		wp_enqueue_script( 'wsuwp-network-users', plugins_url( '/js/wsuwp-network-users.js', __FILE__ ), array( 'jquery' ), wsuwp_global_version(), true );
 
-		$network_id = absint( wsuwp_get_current_network()->id );
+		$network_id = absint( get_current_network_id() );
 
 		$query->query_from = 'FROM wp_users INNER JOIN wp_usermeta ON (wp_users.ID = wp_usermeta.user_id)';
 		$query->query_where = "WHERE 1=1 AND (wp_usermeta.meta_key = 'wsuwp_network_" . $network_id . "_capabilities' )";


### PR DESCRIPTION
WordPress 4.6 will include a handful of functions that make life easier.

Where possible, we should use:

* `get_network()`
* `get_networks()`
* `get_site()`
* `get_sites()`

This should not be merged until the relevant parts of 4.6 are live.