### PR TITLE
[PR] Provide a list of columns to search for network users

### DIFF
--- a/www/wp-content/mu-plugins/wsu-network-users.php
+++ b/www/wp-content/mu-plugins/wsu-network-users.php
@@ -499,7 +499,7 @@ class WSU_Network_Users {
 				$search = trim( $search, '*' );
 			}
 
-			$query->query_where .= $query->get_search_sql( $search, $search, $wild );
+			$query->query_where .= $query->get_search_sql( $search, array( 'user_login', 'user_nicename', 'user_email' ), $wild );
 		}
 	}
 


### PR DESCRIPTION
We've been passing a second `$search` incorrectly here for a while
and user searches on networks other than the primary would not
work as a result.