### PR TITLE
[PR] Add helper scripts to sync files from production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ wp-cli.local.yml
 /www/cgi-bin
 /www/html
 
+# Ignore any production SQL that we've imported locally.
+www/*.sql
+www/*.sql.bak
+
 # We don't need to track default plugins and themes here.
 /www/wordpress/wp-content/plugins
 /www/wordpress/wp-content/themes

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ wp-cli.local.yml
 # Ignore all plugins in the wp-content directory by default. We'll explicitly allow those we track here.
 /www/wp-content/plugins/*/
 
+# Ignore the rsync exclude files in the plugin directory.
+/www/wp-content/plugins/exclude*.txt
+
 # Ignore all uploads in the wp-content directory by default.
 /www/wp-content/uploads
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add a script to sync production plugins locally.
 * Add a script to sync production uploads locally.
+* Add a script to sync production db tables locally.
 
 ## 1.4.13 (June 21, 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.x (TBD)
+
+* Add a script to sync production plugins locally.
+* Add a script to sync production uploads locally.
+
 ## 1.4.13 (June 21, 2016)
 
 * Update WordPress 4.5.3

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ The server configuration provisioned on the virtual machine is provided by the [
 1. `vagrant provision` will process provisioning again and ensure the proper services are started.
 1. `vagrant reload` will act as a system reboot for the virtual machine. Data will persist.
 
+### Sync Production Files
+
+**Note:** To use the following commands, access to the production server is required.
+
+* `bin/pull_plugins` will retrieve all plugins in production and sync them with those that are local. Any local plugins with a `.git` file will be ignored. Any local plugins listed in `www/wp-content/plugins/exclude.txt` will be ignored.
+* `bin/pull_site_uploads ID_1 ID_2` will retrieve all uploads for a site in production. `ID_1` should be the ID of the site in production. `ID_2` should be the ID of the site locally.
+
 ## Documentation
 
 Additional documentation on specific pieces of the WSUWP Platform can be found in our `docs/` directory.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ To use the following commands, access to the production server is required. The 
 
 1. Note the ID of the production site either through the dashboard or via a `wp` command.
   * `wp @wsuwp site list | grep web.wsu.edu`
+1. Check the installed theme for the production site and ensure you have a theme in the exact same directory locally.
 1. Create a new site in your local environment through the network dashboard. Note the ID of the site.
 1. `bin/prep_local_db 7 9 web.wsu.edu dev.web.wsu.edu`
   * Exports a copy of the production tables for a site and imports them into the local environment.
@@ -61,6 +62,8 @@ To use the following commands, access to the production server is required. The 
     * Local hostname.
 1. `bin/pull_site_uploads 7 9`
   * Sync uploads from production to the local environment, specifying the remote site ID first and the local site ID second.
+1. Edit your hosts file or add a record to your *-wsuwp-hosts file and `vagrant up`.
+1. Visit the dev site locally!
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -52,18 +52,15 @@ To use the following commands, access to the production server is required. The 
 1. Note the ID of the production site either through the dashboard or via a `wp` command.
   * `wp @wsuwp site list | grep web.wsu.edu`
 1. Create a new site in your local environment through the network dashboard. Note the ID of the site.
-1. Export a copy of the database tables for a specific site from production and then copy it to your local environment:
-  * `wp @wsuwp db export web-wsu.sql --tables=$(wp @wsuwp db tables --url=web.wsu.edu --scope=blog --format=csv)`
-  * `scp wsuwp-prod-01:web-wsu.sql ./www/`
-1. Use the `prep_local_db` command to replace prefixed table names from production with that of the local site and then import the SQL into the local database.
-  * `bin/prep_local_db 7 9 web-wsu.sql`
-1. Search and replace the production URL with the local URL, uses of HTTPS for that URL, and the site ID in the uploads directory.
-  * `wp @local search-replace "web.wsu.edu" "dev.web.wsu.edu" --url=dev.web.wsu.edu`
-  * `wp @local search-replace "https://dev.web.wsu.edu" "http://dev.web.wsu.edu" --url=dev.web.wsu.edu`
-  * `wp @local search-replace "sites/7/" "sites/9/" --url=dev.web.wsu.edu`
-  * `wp @local cache flush`
-1. Sync uploads from production to the local environment, specifying the remote site ID first and the local site ID second.
-  * `bin/pull_site_uploads 7 9`
+1. `bin/prep_local_db 7 9 web.wsu.edu dev.web.wsu.edu`
+  * Exports a copy of the production tables for a site and imports them into the local environment.
+  * Expects these arguments:
+    * Remote site ID.
+    * Local site ID.
+    * Remote hostname.
+    * Local hostname.
+1. `bin/pull_site_uploads 7 9`
+  * Sync uploads from production to the local environment, specifying the remote site ID first and the local site ID second.
 
 ## Documentation
 

--- a/bin/prep_local_db
+++ b/bin/prep_local_db
@@ -1,0 +1,33 @@
+# !/bin/bash
+#
+# Use this script on an OSX or Linux machine to sync plugings on WSUWP with
+# your local environment. This requires access to wsuwp-prod-01 and matching
+# SSH configuration.
+#
+
+re='^[0-9]+$'
+if ! [[ $1 =~ $re ]] ; then
+  echo "Remote site ID is not a number" >&2; exit 1
+fi
+
+if [[ ! $2 =~ $re ]]; then
+  echo "Local site ID is not a number" >&2; exit 1
+fi
+
+if [[ -f 'pull_plugins' ]]; then
+  LOCAL_DB='../www/'
+elif [[ -f 'Vagrantfile' ]]; then
+  LOCAL_DB='www/'
+else
+  echo "Error: Run from the project root or bin directory"
+  exit
+fi
+
+sed -i.bak s/wp_$1_/wp_$2_/g $LOCAL_DB$3
+
+if test $(which wp)
+then
+  wp @local db import /var/www/$3
+else
+  echo "WP-CLI not found, import database manually."
+fi

--- a/bin/prep_local_db
+++ b/bin/prep_local_db
@@ -14,6 +14,11 @@ if [[ ! $2 =~ $re ]]; then
   echo "Local site ID is not a number" >&2; exit 1
 fi
 
+if ! test $(which wp)
+then
+  echo "WP-CLI is required." >&2; exit 1
+fi
+
 if [[ -f 'pull_plugins' ]]; then
   LOCAL_DB='../www/'
 elif [[ -f 'Vagrantfile' ]]; then
@@ -23,11 +28,15 @@ else
   exit
 fi
 
-sed -i.bak s/wp_$1_/wp_$2_/g $LOCAL_DB$3
+wp @wsuwp db export $3.sql --tables=$(wp @wsuwp db tables --url=$3 --scope=blog --format=csv)
+scp wsuwp-prod-01:$3.sql $LOCAL_DB
 
-if test $(which wp)
-then
-  wp @local db import /var/www/$3
-else
-  echo "WP-CLI not found, import database manually."
-fi
+sed -i.bak s/wp_$1_/wp_$2_/g $LOCAL_DB$3.sql
+echo "Replaced wp_$1 with wp_$2 in $3.sql"
+
+wp @local db import /var/www/$3.sql
+
+wp @local search-replace "$3" "$4" --url=$4
+wp @local search-replace "https://$4" "http://$4" --url=$4
+wp @local search-replace "sites/$1/" "sites/$2/" --url=$4
+wp @local cache flush

--- a/bin/pull_plugins
+++ b/bin/pull_plugins
@@ -1,0 +1,24 @@
+# !/bin/bash
+#
+# Use this script on an OSX or Linux machine to sync plugings on WSUWP with
+# your local environment. This requires access to wsuwp-prod-01 and matching
+# SSH configuration.
+#
+
+if [[ -f 'pull_plugins' ]]; then
+  LOCAL_PLUGINS='../www/wp-content/plugins'
+elif [[ -f 'Vagrantfile' ]]; then
+  LOCAL_PLUGINS='www/wp-content/plugins'
+else
+  echo "Error: Run from the project root or bin directory"
+  exit
+fi
+
+cd $LOCAL_PLUGINS
+
+rm exclude-auto.txt
+for GIT_DIR in $(find . -maxdepth 2 -name '.git'); do
+    echo $(basename $(dirname $GIT_DIR)) >> exclude-auto.txt
+done
+
+rsync -avz --delete --exclude-from 'exclude-auto.txt' --exclude-from 'exclude.txt' --exclude 'exclude-auto.txt' --exclude 'exclude.txt' wsuwp-prod-01:/var/www/wp-content/plugins/ ./

--- a/bin/pull_site_uploads
+++ b/bin/pull_site_uploads
@@ -1,0 +1,28 @@
+# !/bin/bash
+#
+# Use this script on an OSX or Linux machine to sync plugings on WSUWP with
+# your local environment. This requires access to wsuwp-prod-01 and matching
+# SSH configuration.
+#
+
+re='^[0-9]+$'
+if ! [[ $1 =~ $re ]] ; then
+  echo "Remote site ID is not a number" >&2; exit 1
+fi
+
+if [[ ! $2 =~ $re ]]; then
+  echo "Local site ID is not a number" >&2; exit 1
+fi
+
+if [[ -f 'pull_plugins' ]]; then
+  LOCAL_UPLOADS=../www/wp-content/uploads/sites
+elif [[ -f 'Vagrantfile' ]]; then
+  LOCAL_UPLOADS=www/wp-content/uploads/sites
+else
+  echo "Error: Run from the project root or bin directory"
+  exit
+fi
+
+cd $LOCAL_UPLOADS
+
+rsync -avz --delete wsuwp-prod-01:/var/www/wp-content/uploads/sites/$1/ ./$2


### PR DESCRIPTION
* `pull_plugins` will pull all plugins from production, ignoring the ones that you have cloned as git repositories and any specified in an `exclude.txt` file.
* `pull_site_uploads` will synchronize the uploads from a site ID in production to a site ID locally.
* `prep_local_db` will prep an already exported database file and import it to the local environment.
* The README has been updated with an initial structure for retrieving remote data for use locally.

Fixes #343.