### PR TITLE
[PR] Remove `wsuwp_get_current_site()`

### DIFF
--- a/www/wp-content/mu-plugins/wsu-core-functions.php
+++ b/www/wp-content/mu-plugins/wsu-core-functions.php
@@ -56,17 +56,6 @@ function wsuwp_get_current_network() {
 }
 
 /**
- * A wrapper with a better name for get_blog_details(). Returns what WordPress knows
- * as the current blog (by not passing any arguments), which in reality is the
- * current site.
- *
- * @return object with current site information
- */
-function wsuwp_get_current_site() {
-	return get_site();
-}
-
-/**
  * Switch to another network by backing up the $current_site global so that we can run
  * various queries and functions while impersonating it.
  *


### PR DESCRIPTION
Now that `get_site()` is available and `wsuwp_get_current_site()` is no longer a wrapper for `get_current_blog()`, we can use `get_site()` instead.

Fixes #351 