### PR TITLE
[PR] Update Initial Vagrant settings

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure("2") do |config|
 
   # Settings specific to VirtualBox
   config.vm.provider :virtualbox do |v|
-    v.customize ["modifyvm", :id, "--memory", 512]
+    v.customize ["modifyvm", :id, "--memory", 1024]
     v.name = "wsuwp_dev_vm"
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,6 +27,8 @@ Vagrant.configure("2") do |config|
   config.vm.box     = "centos-64-x64-puppetlabs"
   config.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210-nocm.box"
 
+  config.ssh.forward_agent = false
+
   # Set the default hostname and IP address for the virtual machine. If you have any other
   # Vagrant environments on the 10.10.50.x subnet, you may want to consider modifying this.
   config.vm.hostname = "wsuwp"

--- a/bin/pull_plugins
+++ b/bin/pull_plugins
@@ -16,7 +16,16 @@ fi
 
 cd $LOCAL_PLUGINS
 
-rm exclude-auto.txt
+if [[ ! -f 'exclude.txt' ]]; then
+  touch exclude.txt
+fi
+
+if [[ -f 'exclude-auto.txt' ]]; then
+  rm exclude-auto.txt
+fi
+
+touch exclude-auto.txt
+
 for GIT_DIR in $(find . -maxdepth 2 -name '.git'); do
     echo $(basename $(dirname $GIT_DIR)) >> exclude-auto.txt
 done


### PR DESCRIPTION
- Disable agent forwarding. With this enabled, Ubuntu has issues loading the virtual machine. It should not affect any of our workflows.
- Update base box size to 1GB from 512MB.
