### PR TITLE
[PR] Fix My Sites and My Networks menu generation logic

### DIFF
--- a/www/wp-content/mu-plugins/wsu-admin-header.php
+++ b/www/wp-content/mu-plugins/wsu-admin-header.php
@@ -16,6 +16,8 @@ class WSU_Admin_Header {
 		add_action( 'admin_head', array( $this, 'admin_bar_css' ), 10 );
 		add_action( 'wp_head', array( $this, 'admin_bar_css' ), 10 );
 		add_action( 'admin_bar_init',        array( $this, 'set_user_networks' ),  10 );
+		add_action( 'admin_init', array( $this, 'remove_my_sites_menu' ), 11 );
+		add_action( 'template_redirect', array( $this, 'remove_my_sites_menu' ), 11 );
 		add_action( 'admin_bar_menu',        array( $this, 'my_networks_menu' ), 210 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 10 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ), 10 );
@@ -71,6 +73,16 @@ class WSU_Admin_Header {
 		if ( ! isset( $wp_admin_bar->user->networks ) ) {
 			$wp_admin_bar->user->networks = wsuwp_get_user_networks();
 		}
+	}
+
+	/**
+	 * Removes the default My Sites menu rendering performed by WordPress core. WSUWP
+	 * re-renders this menu and this avoids doubling the effort.
+	 *
+	 * @since 1.5.7
+	 */
+	public function remove_my_sites_menu() {
+		remove_action( 'admin_bar_menu', 'wp_admin_bar_my_sites_menu', 20 );
 	}
 
 	/**

--- a/www/wp-content/mu-plugins/wsu-admin-header.php
+++ b/www/wp-content/mu-plugins/wsu-admin-header.php
@@ -93,7 +93,7 @@ class WSU_Admin_Header {
 		$user_sites = 0;
 
 		foreach ( $user_meta_keys as $key ) {
-			if ( 'capabilities' !== substr( $key, -12 ) ) {
+			if ( 'capabilities' !== substr( $key, -12 ) || strpos( $key, 'network' ) !== false || strpos( $key, 'global' ) !== false  ) {
 				continue;
 			}
 

--- a/www/wp-content/mu-plugins/wsu-core-functions.php
+++ b/www/wp-content/mu-plugins/wsu-core-functions.php
@@ -30,7 +30,10 @@ function wsuwp_get_user_networks( $user_id = null ) {
 	}
 
 	$user_id = absint( $user_id );
-	$sql = $wpdb->prepare( "SELECT meta_key FROM $wpdb->usermeta WHERE user_id = %d AND meta_key LIKE 'wsuwp_network_%_capabilities'", $user_id );
+
+	$sql = $wpdb->prepare( "SELECT meta_key FROM $wpdb->usermeta WHERE user_id = %d", $user_id );
+	$sql .= " AND meta_key LIKE 'wsuwp_network_%_capabilities'";
+
 	$network_keys = $wpdb->get_col( $sql ); // WPCS: unprepared SQL OK.
 
 	$user_network_ids = array();


### PR DESCRIPTION
A few things:

* Prevent WordPress from rendering the initial My Sites menu before we generate anything. In many cases we're regenerating that same menu anyway for each network.
* Correct the query used to retrieve a user's networks. As of 09/2016, a request for a user's networks would always return all networks. This resultsed in a My Networks menu appearing for everyone even if they belonged to only 1 network. :disappointed:
* When determining how many sites a user is a member of, don't accidentally check the global and network capabilities. This resulted in a My Sites (or My Networks) menu appearing for everyone regardless of the number of sites they belonged to.
* Store and capture the current site's admin bar menu so that we can ensure things are displayed in the proper order.