### PR TITLE
[PR] Disable My Sites and My Networks menus for global admins

### DIFF
--- a/www/wp-content/mu-plugins/wsu-admin-header.php
+++ b/www/wp-content/mu-plugins/wsu-admin-header.php
@@ -70,6 +70,10 @@ class WSU_Admin_Header {
 	public function set_user_networks() {
 		global $wp_admin_bar;
 
+		if ( wsuwp_is_global_admin( wp_get_current_user()->ID ) ) {
+			return;
+		}
+
 		if ( ! isset( $wp_admin_bar->user->networks ) ) {
 			$wp_admin_bar->user->networks = wsuwp_get_user_networks();
 		}
@@ -225,6 +229,11 @@ class WSU_Admin_Header {
 			if ( 1 < $user_sites ) {
 				break;
 			}
+		}
+
+		// Disable the My Sites and My Networks menu for global admins.
+		if ( wsuwp_is_global_admin( wp_get_current_user()->ID ) ) {
+			return;
 		}
 
 		/**


### PR DESCRIPTION
This reduces the peak memory load of PHP (at our current site level) about 65MB per page view, bringing it down to 6MB. Sweet.

This will also reduce the amount of time each page view takes by a ton.