### PR TITLE
[PR] Group REST API URLs as one URL version for page cache busting

### DIFF
--- a/www/wp-content/advanced-cache.php
+++ b/www/wp-content/advanced-cache.php
@@ -389,7 +389,13 @@ if ( $batcache->is_ssl() )
 
 // Recreate the permalink from the URL
 $batcache->permalink = 'http://' . $batcache->keys['host'] . $batcache->keys['path'] . ( isset($batcache->keys['query']['p']) ? "?p=" . $batcache->keys['query']['p'] : '' );
-$batcache->url_key = md5($batcache->permalink);
+
+if ( preg_match( '/wp-json\/wp\//', $_SERVER['REQUEST_URI'] ) ) {
+	$batcache->url_key = md5( 'rest-api' );
+} else {
+	$batcache->url_key = md5( $batcache->permalink );
+}
+
 $batcache->configure_groups();
 $batcache->url_version = (int) wp_cache_get("{$batcache->url_key}_version", $batcache->group);
 $batcache->do_variants();


### PR DESCRIPTION
This is inefficient, but allows us to bust page cache for REST API
calls.