### PR TITLE
[PR] Restore Vagrant www-data permissions when mounting drives

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,7 +39,7 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 22, host: 2200, auto_correct: true
 
   # Mount this project's working directory as /var/www inside the virtual machine.
-  config.vm.synced_folder "./www", "/var/www", :mount_options => [ "uid=510,gid=510", "dmode=775", "fmode=774" ]
+  config.vm.synced_folder "./www", "/var/www", owner: "www-data", group: "www-data", :mount_options => [ "uid=510,gid=510", "dmode=775", "fmode=774" ]
 
   # Mount the local project's pillar/ directory as /srv/pillar inside the virtual machine. This allows
   # us to pass arbitrary data to Salt during provisioning.


### PR DESCRIPTION
I think I changed this before because of Linux and now without it OSX has some weirdness in file upload permissions.