### PR TITLE
Hotfix: Suppress errors from `getimagesize()`

### DIFF
--- a/www/wordpress/wp-admin/includes/image.php
+++ b/www/wordpress/wp-admin/includes/image.php
@@ -371,7 +371,7 @@ function wp_read_image_metadata( $file ) {
 	 * as caption, description etc.
 	 */
 	if ( is_callable( 'iptcparse' ) ) {
-		getimagesize( $file, $info );
+		@getimagesize( $file, $info );
 
 		if ( ! empty( $info['APP13'] ) ) {
 			$iptc = iptcparse( $info['APP13'] );


### PR DESCRIPTION
`getimagesize()` does not handle stream data that well, so in a way these `extraneous bytes` errors that we're seeing in the PHP logs are themselves extraneous... 🥁 

See https://core.trac.wordpress.org/ticket/42480 for more background and how this may be resolved in the next release of WP after 4.9.