### PR TITLE
[PR] Skip building a page cache when a REST API request

### DIFF
--- a/www/wp-content/advanced-cache.php
+++ b/www/wp-content/advanced-cache.php
@@ -332,7 +332,7 @@ if ( preg_match( '/documents\/([0-9]{4})\/([0-9]{1,2})\/([^.]+)\.[A-Za-z0-9]{3,4
 
 // Never batcache REST API content
 if ( preg_match( '/wp-json\//', $_SERVER['REQUEST_URI'] ) ) {
-	$batcache->url_key = md5( 'rest-api' );
+	return;
 }
 
 // Never batcache WP javascript generators

--- a/www/wp-content/advanced-cache.php
+++ b/www/wp-content/advanced-cache.php
@@ -330,6 +330,11 @@ if ( preg_match( '/documents\/([0-9]{4})\/([0-9]{1,2})\/([^.]+)\.[A-Za-z0-9]{3,4
 	return;
 }
 
+// Never batcache REST API content
+if ( preg_match( '/wp-json\//', $_SERVER['REQUEST_URI'] ) ) {
+	$batcache->url_key = md5( 'rest-api' );
+}
+
 // Never batcache WP javascript generators
 if ( strstr( $_SERVER['SCRIPT_FILENAME'], 'wp-includes/js' ) )
 	return;
@@ -389,12 +394,7 @@ if ( $batcache->is_ssl() )
 
 // Recreate the permalink from the URL
 $batcache->permalink = 'http://' . $batcache->keys['host'] . $batcache->keys['path'] . ( isset($batcache->keys['query']['p']) ? "?p=" . $batcache->keys['query']['p'] : '' );
-
-if ( preg_match( '/wp-json\/wp\//', $_SERVER['REQUEST_URI'] ) ) {
-	$batcache->url_key = md5( 'rest-api' );
-} else {
-	$batcache->url_key = md5( $batcache->permalink );
-}
+$batcache->url_key = md5( $batcache->permalink );
 
 $batcache->configure_groups();
 $batcache->url_version = (int) wp_cache_get("{$batcache->url_key}_version", $batcache->group);


### PR DESCRIPTION
We can't guarantee that REST API requests are unique based on the URL alone. When different arguments are passed as part of the body of the request, we won't see expected results.