### PR TITLE
Update readme to mirror initial repo setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Once VVV is installed, copy the `vvv-config.yml` file to `vvv-custom.yml` and ad
 wsuwp:
   repo: https://github.com/washingtonstateuniversity/wsuwp-platform.git
   hosts:
-    - wp.wsu.test
+    - wsuwp.test
 ```
 
 Once this is part of your `vvv-custom.yml` file, run `vagrant provision` or `vagrant provision --provision-with=site-wsuwp` to get started.


### PR DESCRIPTION
I think I figured out why my vvv local instance of the platform wasn't working, the url on the readme doesn't match up with the one in the repo for the initial configuration. If you could take a look and let me know if i'm right that'd be good. If I am, this PR will update the readme to more accurately take a new user from nothing to working WSU platform in VVV. 